### PR TITLE
Feat/admin invite flow

### DIFF
--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -28,7 +28,6 @@ Associados devem ter status operacional independente da autenticação:
 | --- | --- |
 | `active` | Associado com acesso válido. |
 | `inactive` | Associado sem acesso ativo no momento. |
-| `suspended` | Associado temporariamente bloqueado por decisão administrativa. |
 
 Administradores também devem ter status:
 
@@ -36,7 +35,6 @@ Administradores também devem ter status:
 | --- | --- |
 | `active` | Pode acessar a administração. |
 | `inactive` | Não pode acessar a administração. |
-| `suspended` | Bloqueio administrativo explícito. |
 
 ## Modelo de dados inicial
 
@@ -101,13 +99,13 @@ Campos sugeridos:
 
 ## Regras de autorização
 
-1. Usuário autenticado sem vínculo em `admin_memberships`, `associate_memberships` ou `supporter_profiles` não deve acessar áreas internas.
+1. Usuário autenticado sem vínculo em `admin_memberships`, `associate_memberships` ou `supporter_profiles` não deve acessar áreas internas. (thales> nao tem vinculo, nao acessa. recebe mensagem de que nao em autorização de acesso.)
 2. A área administrativa exige `admin_memberships.status = active`.
 3. A área do associado exige `associate_memberships.status = active`.
 4. A área do apoiador exige cadastro em `supporter_profiles` com status válido.
 5. Administradores podem conceder ou alterar acesso de associados.
 6. Administradores podem conceder acesso administrativo conforme regra definida no bootstrap.
-7. Status `inactive` e `suspended` bloqueiam acesso à área correspondente.
+7. Status `inactive` bloqueia acesso à área correspondente.
 
 ## Bootstrap de administradores
 

--- a/docs/associate-access-spec.md
+++ b/docs/associate-access-spec.md
@@ -1,0 +1,218 @@
+# Especificação inicial da concessão de acesso e ficha do associado
+
+Issue de origem: [#8 Modelar ficha cadastral do associado](https://github.com/thalescampelodac/landing-page-aajf/issues/8)
+
+## Objetivo
+
+Definir como um novo associado nasce no sistema, quais dados compõem sua ficha
+cadastral e como esse acesso será concedido para permitir testes reais da área
+do associado.
+
+Esta issue deve servir de ponte entre:
+
+- a gestão administrativa de associados
+- a área do associado
+- a modelagem persistente da ficha cadastral
+
+## Problema que a issue resolve
+
+Hoje a área do associado já tem direção visual, mas ainda depende de dados reais
+para validação ponta a ponta.
+
+Sem a `#8`, continuamos com:
+
+- dados apenas de exemplo
+- ausência de concessão operacional de novos associados
+- dificuldade para testar login e experiência real do associado
+
+## Resultado esperado
+
+Ao final desta issue, a administração deve conseguir:
+
+1. conceder acesso a um novo associado;
+2. preencher ou iniciar a ficha cadastral desse associado;
+3. permitir que o associado entre e visualize sua área com dados reais.
+
+## Direção funcional
+
+### 1. Concessão de acesso
+
+O acesso do associado deve nascer por ação administrativa.
+
+Fluxo esperado:
+
+1. a administração localiza ou cria a pessoa no sistema;
+2. a administração concede o vínculo de associado;
+3. o status inicial fica ativo;
+4. a ficha cadastral passa a existir para aquele perfil;
+5. o associado consegue entrar e acessar a área do associado.
+
+### 2. Ficha cadastral
+
+A ficha do associado deve conter, no mínimo:
+
+- foto
+- nome completo
+- email
+- categoria
+- CPF
+- RG
+- telefone com DDD
+- data de nascimento
+- naturalidade
+- endereço com CEP
+- observação
+- lista de dependentes
+
+Cada dependente deve conter:
+
+- nome completo
+- categoria
+- CPF
+- RG
+- data de nascimento
+- naturalidade
+
+### 3. Termo de responsabilidade
+
+O associado deve ter acesso ao texto do termo na própria área.
+
+Também deve existir campo que registre o aceite do termo.
+
+Ponto a definir na implementação:
+
+- o aceite será apenas visual e editável pelo próprio associado?
+- ou ficará persistido com data/hora no banco?
+
+Minha recomendação:
+
+- persistir boolean + timestamp de aceite
+
+## Regras de negócio herdadas da #7
+
+Estas regras já devem ser respeitadas na modelagem:
+
+- um administrador pode e deve ser um associado
+- um associado pode ou não ser um administrador
+- os controles de associado e administrador devem ser mantidos separados
+- o mesmo email pode ter vínculo de associado e papel administrativo sem misturar as permissões
+
+## Estrutura de dados sugerida
+
+Além de `aajf.associate_memberships`, esta issue provavelmente exigirá uma
+tabela dedicada para os dados cadastrais do associado.
+
+### Sugestão de tabela principal
+
+`aajf.associate_profiles`
+
+Campos sugeridos:
+
+- `id`
+- `profile_id`
+- `photo_url`
+- `full_name`
+- `category`
+- `cpf`
+- `rg`
+- `phone`
+- `birth_date`
+- `nationality`
+- `cep`
+- `street`
+- `number`
+- `complement`
+- `neighborhood`
+- `city`
+- `state`
+- `observation`
+- `term_accepted`
+- `term_accepted_at`
+- `created_at`
+- `updated_at`
+
+### Sugestão de tabela de dependentes
+
+`aajf.associate_dependents`
+
+Campos sugeridos:
+
+- `id`
+- `associate_profile_id`
+- `full_name`
+- `category`
+- `cpf`
+- `rg`
+- `birth_date`
+- `nationality`
+- `created_at`
+- `updated_at`
+
+## Separação entre quem edita o quê
+
+### Administração
+
+Deve poder:
+
+- conceder o vínculo de associado
+- ativar, inativar ou suspender
+- consultar a ficha
+- completar ou revisar dados quando necessário
+
+### Associado
+
+Deve poder editar:
+
+- foto
+- nome completo
+- categoria
+- CPF
+- RG
+- telefone
+- data de nascimento
+- naturalidade
+- endereço
+- dependentes
+- observação
+
+## Estados importantes
+
+### Estado 1: perfil autenticado sem vínculo de associado
+
+Não entra na área do associado.
+
+### Estado 2: perfil autenticado com vínculo inativo ou suspenso
+
+Recebe bloqueio amigável.
+
+### Estado 3: perfil autenticado com vínculo ativo
+
+Entra na área do associado e vê a ficha.
+
+## Testes que esta issue deve destravar
+
+Ao final da implementação, precisamos conseguir testar:
+
+- concessão de um novo associado pela administração
+- primeiro acesso do associado
+- visualização da ficha na área do associado
+- edição de dados permitidos
+- presença de dependentes
+- carteira visual refletindo os dados persistidos
+
+## Perguntas em aberto
+
+1. A criação do perfil de associado será separada da concessão do membership ou tudo no mesmo fluxo?
+2. A administração vai cadastrar primeiro e o associado depois só complementa?
+3. O campo `email` da ficha será sempre derivado de `profiles.email`?
+4. Como o upload da foto será persistido?
+5. O termo precisa de trilha de auditoria além do aceite simples?
+
+## Critérios de aceite propostos
+
+- a administração consegue conceder acesso a um novo associado
+- a ficha cadastral básica do associado existe em banco
+- dependentes podem ser persistidos
+- o associado ativo consegue acessar sua área com dados reais
+- a área do associado reflete a ficha persistida
+- as regras de separação entre acesso administrativo e acesso de associado são preservadas

--- a/docs/associate-area-spec.md
+++ b/docs/associate-area-spec.md
@@ -48,31 +48,44 @@ Este bloco deve reunir as informações principais da ficha cadastral.
 
 Sugestão inicial de campos:
 
+- foto (upload de imagem. aplicar todas as regras para que uma foto posso ser usada)
 - nome completo
 - email
-- telefone
-- documento principal
+- categoria: 
+    - Kleine Kinder
+    - Gosse Kinder
+    - Heimweh
+- CPF
+- RG
+- telefone (com DDD)
 - data de nascimento
-- endereço
+- naturalidade (lista de seleção para naturalidades. exemplo: brasileira, alemã, portuguesa, e assim por diante)
+- endereço (usar consulta por CEP para preenchimento automatico dos campos - CEP tbm é uma inforção que será guardada no banco de dados)
+- dependente (aqui será uma listagem de dependentes. deve sr um espação para incluir o primeiro dependente e adivionar tantos outros quanto necessario, entao tem que deixar aquela div com "+", sabe qual é?)
+    - nome completo
+    - categoria
+    - CPF
+    - RG
+    - data de nascimento
+    - naturalidade
+- observação
 
-Observação:
-
-Esta lista ainda precisa ser fechada com a definição da ficha cadastral real.
 
 ### 2. Situação do vínculo
 
 Este bloco deve exibir informações do relacionamento do usuário com a associação.
 
-Sugestão inicial:
+Deixar em algum lugar esse texto para ser lido:
 
-- status do associado
-- data de concessão
-- observações institucionais, se houver
+"Por meio deste instrumento, declaro me responsabilizar pela guarda e conservação do TRAJE FOLCLÓRICO do GRUPO DE DANÇAS FOLCLÓRICAS GERMÂNICAS SCHMETTERLING de propriedade da ASSOCIAÇÃO ALEMÃ DE JUIZ DE FORA/MG, inscrita no CNPJ 73.627.960/0001-50 pelo tempo que estiver associado a entidade e integrar o referido grupo. 
 
-Objetivo:
+Me comprometo a devolver o mencionado bem em perfeito estado de conservação, como atualmente se encontra.
 
-- deixar claro se o vínculo está ativo, inativo ou suspenso
-- evitar que o usuário dependa de atendimento para entender sua situação
+Em caso de extravio ou danos que provoquem a perda total ou parcial do bem, fico obrigado a ressarcir a Associação Alemã de Juiz de Fora/MG dos prejuízos ocasionados."
+
+E um check para ser marcado com o texto "Declaro ter lido e estar de pleno acordo com o termo acima descrito."
+
+eu não acredito que seja necessario exibir situação, uma vez que a unica situação atual possivel para que um associado veja ao entrar seja o de ativo. pela logica, se ele entrou entao ele é ativo.
 
 ### 3. Segurança da conta
 
@@ -82,12 +95,9 @@ Escopo inicial:
 
 - alteração de senha
 - informação sobre método de acesso atual
-
-Exemplos:
-
-- conta com login Google
-- conta com email e senha
-- conta com ambos os meios habilitados
+    - conta com login Google
+    - conta com email e senha
+    - conta com ambos os meios habilitados
 
 ### 4. Informações complementares
 
@@ -97,32 +107,36 @@ Este bloco pode ser usado depois para exibir:
 - dados adicionais do cadastro
 - conteúdos exclusivos do associado
 
-Por enquanto, ele pode nascer vazio ou como espaço reservado.
+Por enquanto, nascercomo espaço reservado.
 
 ## Edição de dados
 
-Precisamos separar claramente o que o associado poderá editar e o que será apenas leitura.
+somente os seguintes dados poderão ser editados pelo usuario:
 
-### Campos potencialmente editáveis pelo associado
-
-Sugestão inicial:
-
-- telefone
-- endereço
-- alguns dados complementares de contato
-
-### Campos que tendem a ser apenas leitura
-
-Sugestão inicial:
-
-- status do vínculo
-- papel/perfil institucional
-- data de concessão
-- informações sensíveis definidas pela administração
+- foto
+- nome completo
+- categoria: 
+    - Kleine Kinder
+    - Gosse Kinder
+    - Heimweh
+- CPF
+- RG
+- telefone (com DDD)
+- data de nascimento
+- naturalidade (lista de seleção para naturalidades. exemplo: brasileira, alemã, portuguesa, e assim por diante)
+- endereço (usar consulta por CEP para preenchimento automatico dos campos - CEP tbm é uma inforção que será guardada no banco de dados)
+- dependente (aqui será uma listagem de dependentes. deve sr um espação para incluir o primeiro dependente e adivionar tantos outros quanto necessario, entao tem que deixar aquela div com "+", e tambem disponibilizar uma forma de remover o dependente)
+    - nome completo
+    - categoria
+    - CPF
+    - RG
+    - data de nascimento
+    - naturalidade
+- observação
 
 ## Alteração de senha
 
-Já foi decidido que a área do associado deve conter um espaço para alteração de senha.
+Já foi decidido que a área do associado deve conter um espaço para alteração de senha em bloco separado com ação dedicada.
 
 Este bloco deve:
 
@@ -166,28 +180,10 @@ Separação recomendada:
 
 Isso significa que a modelagem dos dados deve ser compatível entre os dois módulos.
 
-## Dependências para implementação
-
-Antes da implementação completa da `#7`, ainda precisamos fechar:
-
-- quais campos compõem a ficha cadastral do associado
-- quais campos o associado pode editar
-- quais campos são apenas leitura
-- como o status será apresentado visualmente
-
-## Perguntas em aberto
-
-1. Quais campos exatos da ficha cadastral entram na área do associado?
-2. Quais desses campos o associado pode editar sozinho?
-3. A alteração de senha será feita inline na mesma página ou em bloco separado com ação dedicada?
-4. Devemos mostrar histórico ou apenas estado atual do vínculo?
-5. Haverá conteúdos exclusivos do associado além do cadastro?
-
 ## Critérios de aceite propostos
 
 - o associado autenticado e ativo consegue acessar sua área
 - a área exibe seus dados principais
-- a área mostra o status do vínculo
 - a área oferece alteração de senha
 - a interface separa claramente leitura e edição
 - o fluxo funciona bem em desktop e mobile
@@ -201,10 +197,19 @@ Este documento ainda não fecha:
 - histórico detalhado do vínculo
 - conteúdos editoriais exclusivos para associados
 
-## Próximo passo sugerido
+## Carteira visual na tela
 
-Antes da implementação visual completa, vale fazer um refinamento curto deste documento para fechar:
+- aparece dentro da área do associado
+- incluir os seguintes dados:
+    - foto se tiver
+    - nome completo
+    - categoria: 
+    - CPF
+    - data de nascimento
+    - naturalidade (lista de seleção para naturalidades. exemplo: brasileira, alemã, portuguesa, e assim por diante)
 
-- lista final dos campos
-- campos editáveis
-- blocos definitivos da página
+## Regras de negocio
+
+- um administrador pode e deve ser um associado
+- um associado pode ou nao ser um administrador
+- os acessos e controles de administrador e de um associado devem ser mantidos separadamente. um mesmo email deve ter seus acessos de associado e administrador separados.

--- a/src/app/access-routes.test.tsx
+++ b/src/app/access-routes.test.tsx
@@ -3,11 +3,8 @@ import { vi } from "vitest";
 import ApoiadorPage from "@/app/apoiador/page";
 import AssociadoPage from "@/app/associado/page";
 
-vi.mock("@/lib/supabase/associate-profile", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/supabase/associate-profile")>();
-
+vi.mock("@/lib/supabase/associate-profile", async () => {
   return {
-    ...actual,
     getAssociateAreaData: vi.fn(async () => ({
       access: {
         email: "associado@example.com",
@@ -48,15 +45,13 @@ describe("placeholder routes", () => {
   it("renderiza a area do associado", async () => {
     render(await AssociadoPage());
     expect(
-      screen.getByRole("heading", {
-        name: /Sua área pessoal para acompanhar o vínculo com a associação/i,
-      }),
+      screen.getByText(/^Dados do Associado$/i),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: /Senha e método de acesso/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: /Carteira do Associado/i }),
+      screen.getByRole("button", { name: /Visualizar carteirinha/i }),
     ).toBeInTheDocument();
   });
 

--- a/src/app/access-routes.test.tsx
+++ b/src/app/access-routes.test.tsx
@@ -1,15 +1,62 @@
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 import ApoiadorPage from "@/app/apoiador/page";
 import AssociadoPage from "@/app/associado/page";
 
+vi.mock("@/lib/supabase/associate-profile", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/associate-profile")>();
+
+  return {
+    ...actual,
+    getAssociateAreaData: vi.fn(async () => ({
+      access: {
+        email: "associado@example.com",
+        profileId: "associate-profile-id",
+        status: "authorized",
+      },
+      authMethods: {
+        hasGoogle: true,
+        hasPassword: false,
+      },
+      profile: {
+        addressCity: "Juiz de Fora",
+        addressComplement: "",
+        addressNeighborhood: "Borboleta",
+        addressNumber: "23",
+        addressState: "MG",
+        addressStreet: "Rua Braz Xavier Bastos Júnior",
+        birthDate: "1993-08-14",
+        category: "Heimweh",
+        cep: "36035-160",
+        cpf: "000.000.000-00",
+        dependents: [],
+        email: "associado@example.com",
+        fullName: "Associado de Exemplo",
+        nationality: "Brasileira",
+        observation: "Observação de teste",
+        phone: "(32) 99999-0000",
+        photoUrl: null,
+        profileId: "associate-profile-id",
+        rg: "MG-00.000.000",
+        termAccepted: true,
+      },
+    })),
+  };
+});
+
 describe("placeholder routes", () => {
-  it("renderiza a area do associado", () => {
-    render(<AssociadoPage />);
+  it("renderiza a area do associado", async () => {
+    render(await AssociadoPage());
     expect(
-      screen.getByRole("heading", { name: /vida da associação/i }),
+      screen.getByRole("heading", {
+        name: /Sua área pessoal para acompanhar o vínculo com a associação/i,
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: /Alteração de senha/i }),
+      screen.getByRole("heading", { name: /Senha e método de acesso/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Carteira do Associado/i }),
     ).toBeInTheDocument();
   });
 

--- a/src/app/admin/associados/actions.ts
+++ b/src/app/admin/associados/actions.ts
@@ -75,7 +75,7 @@ export async function grantAssociateAccess(
         manualLink: buildManualFirstAccessLink(
           siteUrl,
           inviteData.properties.hashed_token,
-          inviteData.properties.verification_type,
+          "invite",
           next,
         ),
         manualLinkLabel: "Link provisório de primeiro acesso do associado",
@@ -112,7 +112,7 @@ export async function grantAssociateAccess(
       manualLink: buildManualFirstAccessLink(
         siteUrl,
         recoveryData.properties.hashed_token,
-        recoveryData.properties.verification_type,
+        "recovery",
         next,
       ),
       manualLinkLabel: "Link provisório para liberar o acesso do associado",

--- a/src/app/admin/associados/actions.ts
+++ b/src/app/admin/associados/actions.ts
@@ -1,0 +1,184 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { getRequestSiteUrl } from "@/lib/site-url";
+import { getAdminAccess } from "@/lib/supabase/access";
+import { createClient } from "@/lib/supabase/server";
+
+export type AdminAssociatesActionState = {
+  error?: string;
+  manualLink?: string;
+  manualLinkLabel?: string;
+  success?: string;
+};
+
+export async function grantAssociateAccess(
+  _previousState: AdminAssociatesActionState,
+  formData: FormData,
+): Promise<AdminAssociatesActionState> {
+  const access = await getAdminAccess();
+
+  if (access.status !== "authorized") {
+    return { error: "Apenas administradores ativos podem conceder vínculo de associado." };
+  }
+
+  const email = String(formData.get("email") || "").trim();
+  const status = String(formData.get("status") || "").trim();
+  const notes = String(formData.get("notes") || "").trim();
+
+  if (!email || !email.includes("@")) {
+    return { error: "Informe um email válido para conceder o vínculo de associado." };
+  }
+
+  if (!isValidAssociateStatus(status)) {
+    return { error: "Selecione um status válido para o associado." };
+  }
+
+  const siteUrl = await getRequestSiteUrl();
+  const supabase = await createClient();
+  const { error: grantError } = await supabase
+    .schema("aajf")
+    .from("associate_bootstrap_grants")
+    .upsert(
+      {
+        email,
+        membership_status: status,
+        notes: notes || null,
+        status: "pending",
+      },
+      { onConflict: "normalized_email" },
+    );
+
+  if (grantError) {
+    return { error: grantError.message };
+  }
+
+  try {
+    const adminSupabase = createAdminClient();
+    const next = "/primeiro-acesso?next=%2Fassociado";
+    const redirectTo = `${siteUrl}/auth/confirm?next=${encodeURIComponent(next)}`;
+    const { data: inviteData, error: inviteError } =
+      await adminSupabase.auth.admin.generateLink({
+        type: "invite",
+        email,
+        options: {
+          redirectTo,
+        },
+      });
+
+    if (!inviteError) {
+      revalidatePath("/admin/associados");
+      revalidatePath("/associado");
+
+      return {
+        manualLink: buildManualFirstAccessLink(
+          siteUrl,
+          inviteData.properties.hashed_token,
+          inviteData.properties.verification_type,
+          next,
+        ),
+        manualLinkLabel: "Link provisório de primeiro acesso do associado",
+        success:
+          "Vínculo de associado autorizado por email e link provisório de primeiro acesso gerado com sucesso.",
+      };
+    }
+
+    const isAlreadyRegisteredError =
+      inviteError.message.toLowerCase().includes("already been registered") ||
+      inviteError.message.toLowerCase().includes("already registered");
+
+    if (!isAlreadyRegisteredError) {
+      return { error: inviteError.message };
+    }
+
+    const { data: recoveryData, error: recoveryError } =
+      await adminSupabase.auth.admin.generateLink({
+        type: "recovery",
+        email,
+        options: {
+          redirectTo,
+        },
+      });
+
+    if (recoveryError) {
+      return { error: recoveryError.message };
+    }
+
+    revalidatePath("/admin/associados");
+    revalidatePath("/associado");
+
+    return {
+      manualLink: buildManualFirstAccessLink(
+        siteUrl,
+        recoveryData.properties.hashed_token,
+        recoveryData.properties.verification_type,
+        next,
+      ),
+      manualLinkLabel: "Link provisório para liberar o acesso do associado",
+      success:
+        "O vínculo foi autorizado e um link provisório para entrar ou renovar a senha do associado foi gerado com sucesso.",
+    };
+  } catch (adminClientError) {
+    return {
+      error:
+        adminClientError instanceof Error
+          ? adminClientError.message
+          : "Não foi possível preparar o link do associado.",
+    };
+  }
+}
+
+export async function updateAssociateMembership(
+  _previousState: AdminAssociatesActionState,
+  formData: FormData,
+): Promise<AdminAssociatesActionState> {
+  const access = await getAdminAccess();
+
+  if (access.status !== "authorized") {
+    return { error: "Apenas administradores ativos podem alterar associados." };
+  }
+
+  const membershipId = String(formData.get("membershipId") || "").trim();
+  const status = String(formData.get("status") || "").trim();
+  const notes = String(formData.get("notes") || "").trim();
+
+  if (!membershipId) {
+    return { error: "Registro de associado inválido." };
+  }
+
+  if (!isValidAssociateStatus(status)) {
+    return { error: "Selecione um status válido para o associado." };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .schema("aajf")
+    .from("associate_memberships")
+    .update({ notes: notes || null, status })
+    .eq("id", membershipId);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  revalidatePath("/admin/associados");
+  revalidatePath("/associado");
+
+  return { success: "Vínculo de associado atualizado." };
+}
+
+function isValidAssociateStatus(
+  status: string,
+): status is "active" | "inactive" | "suspended" {
+  return status === "active" || status === "inactive" || status === "suspended";
+}
+
+function buildManualFirstAccessLink(
+  siteUrl: string,
+  tokenHash: string,
+  type: "invite" | "recovery",
+  next: string,
+) {
+  return `${siteUrl}/auth/confirm?token_hash=${encodeURIComponent(tokenHash)}&type=${encodeURIComponent(type)}&next=${encodeURIComponent(next)}`;
+}

--- a/src/app/admin/associados/page.tsx
+++ b/src/app/admin/associados/page.tsx
@@ -1,43 +1,74 @@
 import { redirect } from "next/navigation";
 import { AdminAccessPanel } from "@/components/admin-access-panel";
-import { getAdminAccess } from "@/lib/supabase/access";
+import { AdminAssociatesManager } from "@/components/admin-associates-manager";
+import {
+  getAdminAssociatesData,
+  type AdminAssociatesData,
+} from "@/lib/supabase/admin-associates";
 
 export default async function AdminAssociadosPage() {
-  const access = await getAdminAccess();
+  try {
+    const data = await getAdminAssociatesData();
+    const { access } = data;
 
-  if (access.status === "unauthenticated") {
-    redirect("/entrar?next=/admin/associados");
+    if (access.status === "unauthenticated") {
+      redirect("/entrar?next=/admin/associados");
+    }
+
+    const authorizedData = isAuthorizedAdminAssociatesData(data) ? data : null;
+
+    return (
+      <AdminAccessPanel
+        access={access}
+        authorizedDescription="Este módulo agora concede vínculo de associado, permite revisar status e cria a ponte operacional com a área do associado e a ficha cadastral persistida."
+        authorizedTitle="Gestão de associados e ficha cadastral"
+      >
+      {authorizedData ? (
+        <AdminAssociatesManager
+          bootstrapGrants={authorizedData.bootstrapGrants}
+          memberships={authorizedData.memberships}
+        />
+      ) : null}
+      </AdminAccessPanel>
+    );
+  } catch (error) {
+    return (
+      <section className="soft-card rounded-[2rem] p-8 sm:p-10 lg:p-12">
+        <p className="section-eyebrow">Gestão de associados</p>
+        <h1 className="section-title mt-4 max-w-3xl">
+          O módulo ainda não conseguiu acessar as tabelas novas da ficha cadastral.
+        </h1>
+        <p className="section-description mt-6 max-w-2xl">
+          Isso costuma acontecer quando a migration da `#8` ainda não foi aplicada
+          no Supabase ou quando as permissões/grants dessa migration ainda não
+          entraram em vigor no ambiente atual.
+        </p>
+
+        <div className="mt-8 rounded-[1.5rem] border border-[rgba(154,31,43,0.12)] bg-[rgba(255,250,243,0.74)] p-5">
+          <p className="text-sm font-medium text-[var(--color-red-deep)]">
+            {getErrorMessage(error)}
+          </p>
+          <p className="mt-3 text-sm leading-7 text-[var(--color-green-deep)]">
+            Verifique principalmente a migration
+            `20260503113000_associate_profiles.sql`, que cria `aajf.associate_profiles`
+            e `aajf.associate_dependents` com RLS e grants para `authenticated`.
+          </p>
+        </div>
+      </section>
+    );
+  }
+}
+
+function isAuthorizedAdminAssociatesData(
+  data: AdminAssociatesData,
+): data is Extract<AdminAssociatesData, { access: { status: "authorized" } }> {
+  return data.access.status === "authorized";
+}
+
+function getErrorMessage(error: unknown) {
+  if (error && typeof error === "object" && "message" in error) {
+    return String(error.message);
   }
 
-  return (
-    <AdminAccessPanel
-      access={access}
-      authorizedDescription="Este módulo prepara a futura gestão de associados, concessão de acesso, leitura de status e vínculo com a área do associado."
-      authorizedTitle="Gestão de associados e status"
-    >
-      <div className="grid gap-5 lg:grid-cols-2">
-        <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
-          <p className="section-eyebrow">Próximo passo</p>
-          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-            Concessão de acesso
-          </h3>
-          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-            O objetivo aqui é permitir que a administração conceda e revise o
-            acesso de associados com base no cadastro interno da associação.
-          </p>
-        </article>
-
-        <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
-          <p className="section-eyebrow">Próximo passo</p>
-          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-            Status do vínculo
-          </h3>
-          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-            A estrutura administrativa já reserva espaço para controlar estados
-            como ativo, inativo e suspenso antes da implementação final.
-          </p>
-        </article>
-      </div>
-    </AdminAccessPanel>
-  );
+  return "Nao foi possível carregar os dados administrativos de associados.";
 }

--- a/src/app/admin/associados/page.tsx
+++ b/src/app/admin/associados/page.tsx
@@ -7,56 +7,35 @@ import {
 } from "@/lib/supabase/admin-associates";
 
 export default async function AdminAssociadosPage() {
-  try {
-    const data = await getAdminAssociatesData();
-    const { access } = data;
+  const result = await loadAdminAssociatesResult();
 
-    if (access.status === "unauthenticated") {
-      redirect("/entrar?next=/admin/associados");
-    }
+  if ("error" in result) {
+    return <AdminAssociatesLoadError error={result.error} />;
+  }
 
-    const authorizedData = isAuthorizedAdminAssociatesData(data) ? data : null;
+  const { data } = result;
+  const { access } = data;
 
-    return (
-      <AdminAccessPanel
-        access={access}
-        authorizedDescription="Este módulo agora concede vínculo de associado, permite revisar status e cria a ponte operacional com a área do associado e a ficha cadastral persistida."
-        authorizedTitle="Gestão de associados e ficha cadastral"
-      >
+  if (access.status === "unauthenticated") {
+    redirect("/entrar?next=/admin/associados");
+  }
+
+  const authorizedData = isAuthorizedAdminAssociatesData(data) ? data : null;
+
+  return (
+    <AdminAccessPanel
+      access={access}
+      authorizedDescription="Este módulo agora concede vínculo de associado, permite revisar status e cria a ponte operacional com a área do associado e a ficha cadastral persistida."
+      authorizedTitle="Gestão de associados e ficha cadastral"
+    >
       {authorizedData ? (
         <AdminAssociatesManager
           bootstrapGrants={authorizedData.bootstrapGrants}
           memberships={authorizedData.memberships}
         />
       ) : null}
-      </AdminAccessPanel>
-    );
-  } catch (error) {
-    return (
-      <section className="soft-card rounded-[2rem] p-8 sm:p-10 lg:p-12">
-        <p className="section-eyebrow">Gestão de associados</p>
-        <h1 className="section-title mt-4 max-w-3xl">
-          O módulo ainda não conseguiu acessar as tabelas novas da ficha cadastral.
-        </h1>
-        <p className="section-description mt-6 max-w-2xl">
-          Isso costuma acontecer quando a migration da `#8` ainda não foi aplicada
-          no Supabase ou quando as permissões/grants dessa migration ainda não
-          entraram em vigor no ambiente atual.
-        </p>
-
-        <div className="mt-8 rounded-[1.5rem] border border-[rgba(154,31,43,0.12)] bg-[rgba(255,250,243,0.74)] p-5">
-          <p className="text-sm font-medium text-[var(--color-red-deep)]">
-            {getErrorMessage(error)}
-          </p>
-          <p className="mt-3 text-sm leading-7 text-[var(--color-green-deep)]">
-            Verifique principalmente a migration
-            `20260503113000_associate_profiles.sql`, que cria `aajf.associate_profiles`
-            e `aajf.associate_dependents` com RLS e grants para `authenticated`.
-          </p>
-        </div>
-      </section>
-    );
-  }
+    </AdminAccessPanel>
+  );
 }
 
 function isAuthorizedAdminAssociatesData(
@@ -71,4 +50,40 @@ function getErrorMessage(error: unknown) {
   }
 
   return "Nao foi possível carregar os dados administrativos de associados.";
+}
+
+async function loadAdminAssociatesResult() {
+  try {
+    const data = await getAdminAssociatesData();
+    return { data } as const;
+  } catch (error) {
+    return { error } as const;
+  }
+}
+
+function AdminAssociatesLoadError({ error }: { error: unknown }) {
+  return (
+    <section className="soft-card rounded-[2rem] p-8 sm:p-10 lg:p-12">
+      <p className="section-eyebrow">Gestão de associados</p>
+      <h1 className="section-title mt-4 max-w-3xl">
+        O módulo ainda não conseguiu acessar as tabelas novas da ficha cadastral.
+      </h1>
+      <p className="section-description mt-6 max-w-2xl">
+        Isso costuma acontecer quando a migration da `#8` ainda não foi aplicada
+        no Supabase ou quando as permissões/grants dessa migration ainda não
+        entraram em vigor no ambiente atual.
+      </p>
+
+      <div className="mt-8 rounded-[1.5rem] border border-[rgba(154,31,43,0.12)] bg-[rgba(255,250,243,0.74)] p-5">
+        <p className="text-sm font-medium text-[var(--color-red-deep)]">
+          {getErrorMessage(error)}
+        </p>
+        <p className="mt-3 text-sm leading-7 text-[var(--color-green-deep)]">
+          Verifique principalmente a migration
+          `20260503113000_associate_profiles.sql`, que cria `aajf.associate_profiles`
+          e `aajf.associate_dependents` com RLS e grants para `authenticated`.
+        </p>
+      </div>
+    </section>
+  );
 }

--- a/src/app/admin/permissoes/page.tsx
+++ b/src/app/admin/permissoes/page.tsx
@@ -25,7 +25,6 @@ export default async function AdminPermissoesPage() {
       {authorizedData ? (
         <AdminPermissionsManager
           bootstrapGrants={authorizedData.bootstrapGrants}
-          currentAdminEmail={authorizedData.access.email}
           currentAdminProfileId={authorizedData.access.profileId}
           currentAdminRole={authorizedData.access.role}
           eligibleProfiles={authorizedData.eligibleProfiles}

--- a/src/app/associado/actions.ts
+++ b/src/app/associado/actions.ts
@@ -158,7 +158,10 @@ export async function saveAssociateProfile(
     return { error: "Selecione uma naturalidade válida para o associado." };
   }
 
-  if (photoFile && !associatePhotoAcceptedMimeTypes.includes(photoFile.type)) {
+  if (
+    photoFile &&
+    !(associatePhotoAcceptedMimeTypes as readonly string[]).includes(photoFile.type)
+  ) {
     return { error: "Use uma imagem JPG, PNG ou WEBP para a foto do associado." };
   }
 

--- a/src/app/associado/actions.ts
+++ b/src/app/associado/actions.ts
@@ -1,0 +1,415 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  associatePhotoAcceptedMimeTypes,
+  associatePhotoBucketName,
+  associatePhotoMaxFileSizeInBytes,
+  associateCategoryOptions,
+  nationalityOptions,
+} from "@/lib/supabase/associate-profile-shared";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { createClient } from "@/lib/supabase/server";
+
+export type AssociateProfileActionState = {
+  error?: string;
+  success?: string;
+};
+
+type DependentPayload = {
+  birthDate: string;
+  category: string | null;
+  cpf: string | null;
+  fullName: string;
+  id: string;
+  nationality: string | null;
+  rg: string | null;
+};
+
+export async function saveAssociateProfile(
+  _previousState: AssociateProfileActionState,
+  formData: FormData,
+): Promise<AssociateProfileActionState> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "Sessão indisponível para atualizar os dados do associado." };
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .schema("aajf")
+    .from("associate_memberships")
+    .select("status")
+    .eq("profile_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (membershipError || !membership) {
+    return { error: "A conta atual não possui vínculo ativo de associado." };
+  }
+
+  const fullName = String(formData.get("fullName") || "").trim();
+  const category = String(formData.get("category") || "").trim();
+  const cpf = String(formData.get("cpf") || "").trim();
+  const rg = String(formData.get("rg") || "").trim();
+  const phone = String(formData.get("phone") || "").trim();
+  const birthDate = String(formData.get("birthDate") || "").trim();
+  const nationality = String(formData.get("nationality") || "").trim();
+  const cep = String(formData.get("cep") || "").trim();
+  const street = String(formData.get("addressStreet") || "").trim();
+  const number = String(formData.get("addressNumber") || "").trim();
+  const complement = String(formData.get("addressComplement") || "").trim();
+  const neighborhood = String(formData.get("addressNeighborhood") || "").trim();
+  const city = String(formData.get("addressCity") || "").trim();
+  const state = String(formData.get("addressState") || "").trim();
+  const observation = String(formData.get("observation") || "").trim();
+  const termAccepted = String(formData.get("termAccepted") || "") === "on";
+  const dependentsPayload = String(formData.get("dependentsPayload") || "[]");
+  const photoFileEntry = formData.get("photoFile");
+  const photoFile =
+    photoFileEntry instanceof File && photoFileEntry.size > 0 ? photoFileEntry : null;
+
+  if (!fullName) {
+    return { error: "Informe o nome completo do associado." };
+  }
+
+  if (!category) {
+    return { error: "Selecione a categoria do associado." };
+  }
+
+  if (!cpf) {
+    return { error: "Informe o CPF do associado." };
+  }
+
+  if (!rg) {
+    return { error: "Informe o RG do associado." };
+  }
+
+  if (!phone) {
+    return { error: "Informe o telefone com DDD do associado." };
+  }
+
+  if (!birthDate) {
+    return { error: "Informe a data de nascimento do associado." };
+  }
+
+  if (!nationality) {
+    return { error: "Selecione a naturalidade do associado." };
+  }
+
+  if (!cep) {
+    return { error: "Informe o CEP do associado." };
+  }
+
+  if (!street) {
+    return { error: "Informe a rua do associado." };
+  }
+
+  if (!number) {
+    return { error: "Informe o número do endereço." };
+  }
+
+  if (!complement) {
+    return { error: "Informe o complemento do endereço." };
+  }
+
+  if (!neighborhood) {
+    return { error: "Informe o bairro do associado." };
+  }
+
+  if (!city) {
+    return { error: "Informe a cidade do associado." };
+  }
+
+  if (!state) {
+    return { error: "Informe a UF do associado." };
+  }
+
+  if (!observation) {
+    return { error: "Informe a observação do associado." };
+  }
+
+  if (!termAccepted) {
+    return {
+      error:
+        "O aceite do termo de responsabilidade é obrigatório para salvar a ficha do associado.",
+    };
+  }
+
+  if (category && !associateCategoryOptions.includes(category as (typeof associateCategoryOptions)[number])) {
+    return { error: "Selecione uma categoria válida para o associado." };
+  }
+
+  if (cpf && !isValidCpf(cpf)) {
+    return { error: "Informe um CPF válido para o associado." };
+  }
+
+  if (!isValidPhone(phone)) {
+    return { error: "Informe um telefone válido com DDD." };
+  }
+
+  if (
+    nationality &&
+    !nationalityOptions.includes(nationality as (typeof nationalityOptions)[number])
+  ) {
+    return { error: "Selecione uma naturalidade válida para o associado." };
+  }
+
+  if (photoFile && !associatePhotoAcceptedMimeTypes.includes(photoFile.type)) {
+    return { error: "Use uma imagem JPG, PNG ou WEBP para a foto do associado." };
+  }
+
+  if (photoFile && photoFile.size > associatePhotoMaxFileSizeInBytes) {
+    return { error: "A foto do associado deve ter no máximo 5 MB." };
+  }
+
+  let dependents: DependentPayload[] = [];
+
+  try {
+    dependents = JSON.parse(dependentsPayload) as DependentPayload[];
+  } catch {
+    return { error: "Não foi possível interpretar a lista de dependentes." };
+  }
+
+  for (const dependent of dependents) {
+    if (!dependent.fullName.trim()) {
+      return { error: "Todo dependente precisa ter nome completo." };
+    }
+
+    if (!dependent.category) {
+      return { error: "Todo dependente precisa ter categoria." };
+    }
+
+    if (dependent.cpf && !isValidCpf(dependent.cpf)) {
+      return { error: "Foi encontrado um CPF inválido em dependentes." };
+    }
+
+    if (!dependent.cpf) {
+      return { error: "Todo dependente precisa ter CPF." };
+    }
+
+    if (!dependent.rg?.trim()) {
+      return { error: "Todo dependente precisa ter RG." };
+    }
+
+    if (!dependent.birthDate) {
+      return { error: "Todo dependente precisa ter data de nascimento." };
+    }
+
+    if (!dependent.nationality) {
+      return { error: "Todo dependente precisa ter naturalidade." };
+    }
+
+    if (
+      dependent.category &&
+      !associateCategoryOptions.includes(
+        dependent.category as (typeof associateCategoryOptions)[number],
+      )
+    ) {
+      return { error: "Foi encontrada uma categoria inválida em dependentes." };
+    }
+
+    if (
+      dependent.nationality &&
+      !nationalityOptions.includes(
+        dependent.nationality as (typeof nationalityOptions)[number],
+      )
+    ) {
+      return { error: "Foi encontrada uma naturalidade inválida em dependentes." };
+    }
+  }
+
+  const { data: existingAssociateProfile, error: existingAssociateProfileError } =
+    await supabase
+      .schema("aajf")
+      .from("associate_profiles")
+      .select("id, photo_url")
+      .eq("profile_id", user.id)
+      .maybeSingle();
+
+  if (existingAssociateProfileError) {
+    return { error: existingAssociateProfileError.message };
+  }
+
+  let nextPhotoPath = existingAssociateProfile?.photo_url ?? null;
+
+  if (photoFile) {
+    try {
+      const adminSupabase = createAdminClient();
+      const nextExtension = resolvePhotoExtension(photoFile);
+      const uploadedPhotoPath = `profiles/${user.id}/associate-card.${nextExtension}`;
+      const existingPhotoPath = existingAssociateProfile?.photo_url ?? null;
+
+      const { error: uploadPhotoError } = await adminSupabase.storage
+        .from(associatePhotoBucketName)
+        .upload(uploadedPhotoPath, photoFile, {
+          cacheControl: "3600",
+          contentType: photoFile.type,
+          upsert: true,
+        });
+
+      if (uploadPhotoError) {
+        return { error: uploadPhotoError.message };
+      }
+
+      if (existingPhotoPath && existingPhotoPath !== uploadedPhotoPath) {
+        const { error: removePreviousPhotoError } = await adminSupabase.storage
+          .from(associatePhotoBucketName)
+          .remove([existingPhotoPath]);
+
+        if (removePreviousPhotoError) {
+          return { error: removePreviousPhotoError.message };
+        }
+      }
+
+      nextPhotoPath = uploadedPhotoPath;
+    } catch {
+      return {
+        error:
+          "O upload da foto ainda não está disponível neste ambiente. Verifique a configuração do Storage do Supabase.",
+      };
+    }
+  }
+
+  const { data: profileRecord, error: profileUpsertError } = await supabase
+    .schema("aajf")
+    .from("associate_profiles")
+    .upsert(
+      {
+        birth_date: birthDate || null,
+        category: category || null,
+        cep: cep || null,
+        city: city || null,
+        complement: complement || null,
+        cpf: cpf || null,
+        full_name: fullName,
+        nationality: nationality || null,
+        neighborhood: neighborhood || null,
+        number: number || null,
+        observation: observation || null,
+        phone: phone || null,
+        photo_url: nextPhotoPath,
+        profile_id: user.id,
+        rg: rg || null,
+        state: state || null,
+        street: street || null,
+        term_accepted: termAccepted,
+        term_accepted_at: termAccepted ? new Date().toISOString() : null,
+      },
+      { onConflict: "profile_id" },
+    )
+    .select("id")
+    .single();
+
+  if (profileUpsertError || !profileRecord) {
+    return { error: profileUpsertError?.message ?? "Não foi possível salvar a ficha do associado." };
+  }
+
+  const { error: baseProfileUpdateError } = await supabase
+    .schema("aajf")
+    .from("profiles")
+    .update({ full_name: fullName })
+    .eq("id", user.id);
+
+  if (baseProfileUpdateError) {
+    return { error: baseProfileUpdateError.message };
+  }
+
+  const { error: deleteDependentsError } = await supabase
+    .schema("aajf")
+    .from("associate_dependents")
+    .delete()
+    .eq("associate_profile_id", profileRecord.id);
+
+  if (deleteDependentsError) {
+    return { error: deleteDependentsError.message };
+  }
+
+  if (dependents.length) {
+    const { error: insertDependentsError } = await supabase
+      .schema("aajf")
+      .from("associate_dependents")
+      .insert(
+        dependents.map((dependent) => ({
+          associate_profile_id: profileRecord.id,
+          birth_date: dependent.birthDate || null,
+          category: dependent.category || null,
+          cpf: dependent.cpf || null,
+          full_name: dependent.fullName.trim(),
+          nationality: dependent.nationality || null,
+          rg: dependent.rg || null,
+        })),
+      );
+
+    if (insertDependentsError) {
+      return { error: insertDependentsError.message };
+    }
+  }
+
+  revalidatePath("/associado");
+  revalidatePath("/admin/associados");
+
+  return { success: "Dados do associado atualizados com sucesso." };
+}
+
+function isValidCpf(value: string) {
+  const digits = value.replace(/\D/g, "");
+
+  if (digits.length !== 11) {
+    return false;
+  }
+
+  if (/^(\d)\1{10}$/.test(digits)) {
+    return false;
+  }
+
+  let sum = 0;
+
+  for (let index = 0; index < 9; index += 1) {
+    sum += Number(digits[index]) * (10 - index);
+  }
+
+  let remainder = (sum * 10) % 11;
+
+  if (remainder === 10) {
+    remainder = 0;
+  }
+
+  if (remainder !== Number(digits[9])) {
+    return false;
+  }
+
+  sum = 0;
+
+  for (let index = 0; index < 10; index += 1) {
+    sum += Number(digits[index]) * (11 - index);
+  }
+
+  remainder = (sum * 10) % 11;
+
+  if (remainder === 10) {
+    remainder = 0;
+  }
+
+  return remainder === Number(digits[10]);
+}
+
+function isValidPhone(value: string) {
+  const digits = value.replace(/\D/g, "");
+  return digits.length === 10 || digits.length === 11;
+}
+
+function resolvePhotoExtension(file: File) {
+  if (file.type === "image/png") {
+    return "png";
+  }
+
+  if (file.type === "image/webp") {
+    return "webp";
+  }
+
+  return "jpg";
+}

--- a/src/app/associado/page.tsx
+++ b/src/app/associado/page.tsx
@@ -1,45 +1,91 @@
-export default function AssociadoPage() {
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { AssociateAreaManager } from "@/components/associate-area-manager";
+import {
+  getAssociateAreaData,
+  type AssociateAreaData,
+} from "@/lib/supabase/associate-profile";
+
+export default async function AssociadoPage() {
+  const data = await getAssociateAreaData();
+  const { access } = data;
+
+  if (access.status === "unauthenticated") {
+    redirect("/entrar?next=/associado");
+  }
+
+  const authorizedData = isAuthorizedAssociateAreaData(data) ? data : null;
+
   return (
     <main className="section-shell flex-1 pb-16 pt-8">
-      <section className="soft-card rounded-[2rem] p-8 sm:p-10 lg:p-12">
-        <p className="section-eyebrow">Área do Associado</p>
-        <h1 className="section-title mt-4 max-w-3xl">
-          Um espaço futuro para acompanhar a vida da associação.
-        </h1>
-        <p className="section-description mt-6 max-w-2xl">
-          Esta rota foi preparada para reunir autenticação, dados cadastrais,
-          comunicados e recursos exclusivos para associados.
-        </p>
-        <p className="mt-5 text-base font-medium text-[var(--color-green-deep)]">
-          Área em construção. Em breve, este espaço estará disponível.
-        </p>
-
-        <div className="mt-10 grid gap-5 lg:grid-cols-2">
-          <article className="rounded-[1.6rem] border border-[rgba(26,61,46,0.12)] bg-white/70 p-6">
-            <p className="section-eyebrow">Dados do Associado</p>
-            <h2 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-              Cadastro e informações da conta
-            </h2>
-            <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-              Aqui vamos definir os campos do perfil do associado, histórico de
-              vínculo, formas de contato e demais dados que a associação decidir
-              manter neste ambiente.
-            </p>
-          </article>
-
-          <article className="rounded-[1.6rem] border border-[rgba(26,61,46,0.12)] bg-white/70 p-6">
-            <p className="section-eyebrow">Segurança da Conta</p>
-            <h2 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-              Alteração de senha
-            </h2>
-            <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-              A alteração de senha ficará junto dos dados do associado. Esse
-              espaço também deve concentrar orientações de acesso, recuperação e
-              reforço de segurança da conta.
-            </p>
-          </article>
-        </div>
-      </section>
+      {authorizedData ? (
+        <AssociateAreaManager
+          accessEmail={authorizedData.access.email}
+          authMethods={authorizedData.authMethods}
+          profile={authorizedData.profile}
+        />
+      ) : (
+        <AssociateAccessFallback access={access} />
+      )}
     </main>
   );
+}
+
+function AssociateAccessFallback({
+  access,
+}: {
+  access: Exclude<AssociateAreaData["access"], { status: "authorized" }>;
+}) {
+  return (
+    <section className="soft-card rounded-[2rem] p-8 sm:p-10 lg:p-12">
+      <p className="section-eyebrow">Área do Associado</p>
+      <h1 className="section-title mt-4 max-w-3xl">
+        Seu acesso de associado ainda não está liberado.
+      </h1>
+      <p className="section-description mt-6 max-w-2xl">
+        O login confirma sua identidade, mas a entrada nesta área depende de um
+        vínculo ativo de associado concedido pela associação.
+      </p>
+
+      {access.status === "unconfigured" ? (
+        <p className="mt-5 text-base font-medium text-[var(--color-red-deep)]">
+          Supabase ainda não está configurado neste ambiente.
+        </p>
+      ) : null}
+
+      {access.status === "denied" && access.membershipStatus ? (
+        <p className="mt-5 text-base font-medium text-[var(--color-red-deep)]">
+          Sua conta existe, mas o vínculo de associado está atualmente como{" "}
+          {access.membershipStatus}.
+        </p>
+      ) : null}
+
+      {access.status === "denied" && !access.membershipStatus ? (
+        <p className="mt-5 text-base font-medium text-[var(--color-green-deep)]">
+          Ainda não encontramos um vínculo de associado para esta conta.
+        </p>
+      ) : null}
+
+      {access.status === "denied" && access.email ? (
+        <p className="mt-5 text-base font-medium text-[var(--color-green-deep)]">
+          Conta conectada: {access.email}
+        </p>
+      ) : null}
+
+      <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+        <Link className="primary-button" href="/">
+          Voltar para a pagina inicial
+        </Link>
+        <Link className="secondary-button" href="/entrar?next=/associado">
+          Entrar com outra conta
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function isAuthorizedAssociateAreaData(
+  data: AssociateAreaData,
+): data is Extract<AssociateAreaData, { access: { status: "authorized" } }> {
+  return data.access.status === "authorized";
 }

--- a/src/app/associado/page.tsx
+++ b/src/app/associado/page.tsx
@@ -1,31 +1,30 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { AssociateAreaManager } from "@/components/associate-area-manager";
-import {
-  getAssociateAreaData,
-  type AssociateAreaData,
-} from "@/lib/supabase/associate-profile";
+import type { AssociateAreaData } from "@/lib/supabase/associate-profile-shared";
+import { getAssociateAreaData } from "@/lib/supabase/associate-profile";
 
 export default async function AssociadoPage() {
   const data = await getAssociateAreaData();
-  const { access } = data;
 
-  if (access.status === "unauthenticated") {
+  if (data.access.status === "unauthenticated") {
     redirect("/entrar?next=/associado");
   }
 
-  const authorizedData = isAuthorizedAssociateAreaData(data) ? data : null;
+  if (isAuthorizedAssociateAreaData(data)) {
+    return (
+      <main className="section-shell flex-1 pb-16 pt-8">
+        <AssociateAreaManager
+          authMethods={data.authMethods}
+          profile={data.profile}
+        />
+      </main>
+    );
+  }
 
   return (
     <main className="section-shell flex-1 pb-16 pt-8">
-      {authorizedData ? (
-        <AssociateAreaManager
-          authMethods={authorizedData.authMethods}
-          profile={authorizedData.profile}
-        />
-      ) : (
-        <AssociateAccessFallback access={access} />
-      )}
+      <AssociateAccessFallback access={data.access} />
     </main>
   );
 }

--- a/src/app/associado/page.tsx
+++ b/src/app/associado/page.tsx
@@ -20,7 +20,6 @@ export default async function AssociadoPage() {
     <main className="section-shell flex-1 pb-16 pt-8">
       {authorizedData ? (
         <AssociateAreaManager
-          accessEmail={authorizedData.access.email}
           authMethods={authorizedData.authMethods}
           profile={authorizedData.profile}
         />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,9 +147,9 @@ a {
 
 .nav-chip:hover,
 .badge-chip:hover,
-.primary-button:hover,
-.secondary-button:hover,
-.ghost-button:hover {
+.primary-button:hover:not(:disabled),
+.secondary-button:hover:not(:disabled),
+.ghost-button:hover:not(:disabled) {
   transform: translateY(-2px);
 }
 
@@ -173,7 +173,10 @@ a {
     transform 180ms ease,
     box-shadow 180ms ease,
     background-color 180ms ease,
-    border-color 180ms ease;
+    border-color 180ms ease,
+    color 180ms ease,
+    opacity 180ms ease,
+    filter 180ms ease;
 }
 
 .primary-button {
@@ -192,6 +195,36 @@ a {
   border: 1px solid rgba(255, 247, 236, 0.2);
   background: rgba(255, 255, 255, 0.08);
   color: var(--color-paper);
+}
+
+.primary-button:disabled,
+.secondary-button:disabled,
+.ghost-button:disabled {
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+  filter: saturate(0.72);
+}
+
+.primary-button:disabled {
+  background: linear-gradient(
+    135deg,
+    rgba(23, 54, 45, 0.42),
+    rgba(44, 83, 71, 0.42)
+  );
+  color: rgba(255, 247, 236, 0.7);
+}
+
+.secondary-button:disabled {
+  border-color: rgba(23, 54, 45, 0.08);
+  background: rgba(255, 250, 243, 0.56);
+  color: rgba(24, 47, 38, 0.46);
+}
+
+.ghost-button:disabled {
+  border-color: rgba(255, 247, 236, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 247, 236, 0.56);
 }
 
 .metric-card {

--- a/src/components/admin-associates-manager.tsx
+++ b/src/components/admin-associates-manager.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+import { useActionState, useDeferredValue, useEffect, useState } from "react";
+import {
+  grantAssociateAccess,
+  updateAssociateMembership,
+  type AdminAssociatesActionState,
+} from "@/app/admin/associados/actions";
+import type {
+  AdminAssociateMembershipRecord,
+  AssociateBootstrapGrantRecord,
+} from "@/lib/supabase/admin-associates";
+
+const initialState: AdminAssociatesActionState = {};
+const PAGE_SIZE = 5;
+
+type AdminAssociatesManagerProps = {
+  bootstrapGrants: AssociateBootstrapGrantRecord[];
+  memberships: AdminAssociateMembershipRecord[];
+};
+
+export function AdminAssociatesManager({
+  bootstrapGrants = [],
+  memberships = [],
+}: AdminAssociatesManagerProps) {
+  const safeBootstrapGrants = Array.isArray(bootstrapGrants) ? bootstrapGrants : [];
+  const safeMemberships = Array.isArray(memberships) ? memberships : [];
+  const [grantState, grantAction, isGranting] = useActionState(
+    grantAssociateAccess,
+    initialState,
+  );
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [categoryFilter, setCategoryFilter] = useState("all");
+  const [page, setPage] = useState(1);
+  const deferredQuery = useDeferredValue(query);
+
+  const normalizedQuery = deferredQuery.trim().toLowerCase();
+  const filteredMemberships = safeMemberships.filter((membership) => {
+    const matchesQuery =
+      !normalizedQuery ||
+      membership.profile.email.toLowerCase().includes(normalizedQuery) ||
+      (membership.profile.fullName || "").toLowerCase().includes(normalizedQuery) ||
+      (membership.notes || "").toLowerCase().includes(normalizedQuery);
+
+    const matchesStatus =
+      statusFilter === "all" || membership.status === statusFilter;
+    const matchesCategory =
+      categoryFilter === "all" ||
+      (membership.profileSnapshot?.category || "none") === categoryFilter;
+
+    return matchesQuery && matchesStatus && matchesCategory;
+  });
+
+  const totalPages = Math.max(1, Math.ceil(filteredMemberships.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pagedMemberships = filteredMemberships.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE,
+  );
+
+  useEffect(() => {
+    if (page !== currentPage) {
+      setPage(currentPage);
+    }
+  }, [currentPage, page]);
+
+  return (
+    <div className="grid gap-6">
+      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(20rem,0.95fr)]">
+        <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
+          <p className="section-eyebrow">Associados atuais</p>
+          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
+            Quem já possui vínculo com a associação
+          </h3>
+          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
+            Esta lista já usa `associate_memberships` e o espelho inicial da
+            ficha cadastral para facilitar consulta, status e preparação da área
+            do associado.
+          </p>
+
+          <div className="mt-6 grid gap-4">
+            <div className="grid gap-4 rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,250,243,0.72)] p-4 lg:grid-cols-3">
+              <label className="form-field">
+                <span>Buscar por nome, email ou observação</span>
+                <input
+                  onChange={(event) => {
+                    setQuery(event.target.value);
+                    setPage(1);
+                  }}
+                  placeholder="Digite para filtrar"
+                  value={query}
+                />
+              </label>
+
+              <label className="form-field">
+                <span>Status</span>
+                <select
+                  className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-white/88 px-4 py-3 text-[var(--color-ink)]"
+                  onChange={(event) => {
+                    setStatusFilter(event.target.value);
+                    setPage(1);
+                  }}
+                  value={statusFilter}
+                >
+                  <option value="all">Todos</option>
+                  <option value="active">active</option>
+                  <option value="inactive">inactive</option>
+                  <option value="suspended">suspended</option>
+                </select>
+              </label>
+
+              <label className="form-field">
+                <span>Categoria</span>
+                <select
+                  className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-white/88 px-4 py-3 text-[var(--color-ink)]"
+                  onChange={(event) => {
+                    setCategoryFilter(event.target.value);
+                    setPage(1);
+                  }}
+                  value={categoryFilter}
+                >
+                  <option value="all">Todas</option>
+                  <option value="Kleine Kinder">Kleine Kinder</option>
+                  <option value="Gosse Kinder">Gosse Kinder</option>
+                  <option value="Heimweh">Heimweh</option>
+                  <option value="none">Nao definida</option>
+                </select>
+              </label>
+            </div>
+
+            {filteredMemberships.length ? (
+              <>
+                <div className="overflow-x-auto rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-white/72">
+                  <div className="hidden min-w-[72rem] grid-cols-[1.2fr_1.25fr_0.85fr_1fr_1fr_1.2fr] gap-4 border-b border-[rgba(23,54,45,0.08)] px-5 py-4 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-red)] lg:grid">
+                    <span>Nome</span>
+                    <span>Email</span>
+                    <span>Categoria</span>
+                    <span>Telefone</span>
+                    <span>Status</span>
+                    <span>Ações</span>
+                  </div>
+
+                  <div className="grid gap-0">
+                    {pagedMemberships.map((membership) => (
+                      <AssociateMembershipRow key={membership.id} membership={membership} />
+                    ))}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-sm leading-7 text-[var(--color-muted)]">
+                    Exibindo {pagedMemberships.length} de {filteredMemberships.length} associado(s).
+                  </p>
+
+                  <div className="flex items-center gap-3">
+                    <button
+                      className="secondary-button"
+                      disabled={currentPage === 1}
+                      onClick={() => setPage((current) => Math.max(1, current - 1))}
+                      type="button"
+                    >
+                      Página anterior
+                    </button>
+                    <span className="text-sm font-medium text-[var(--color-green-deep)]">
+                      Página {currentPage} de {totalPages}
+                    </span>
+                    <button
+                      className="secondary-button"
+                      disabled={currentPage === totalPages}
+                      onClick={() =>
+                        setPage((current) => Math.min(totalPages, current + 1))
+                      }
+                      type="button"
+                    >
+                      Próxima página
+                    </button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <p className="text-sm leading-7 text-[var(--color-muted)]">
+                Nenhum associado corresponde aos filtros atuais.
+              </p>
+            )}
+          </div>
+        </article>
+
+        <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-[rgba(255,248,239,0.82)] p-6">
+          <p className="section-eyebrow">Conceder novo vínculo</p>
+          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
+            Autorizar associado por email
+          </h3>
+          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
+            Use este fluxo para conceder acesso de associado por email, mesmo
+            que a pessoa ainda não tenha entrado no sistema. O vínculo do
+            associado e o acesso administrativo permanecem independentes.
+          </p>
+
+          <form action={grantAction} className="mt-6 grid gap-4">
+            <label className="form-field">
+              <span>Email do associado</span>
+              <input name="email" placeholder="pessoa@email.com" type="email" />
+            </label>
+
+            <label className="form-field">
+              <span>Status inicial</span>
+              <select
+                className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-white/88 px-4 py-3 text-[var(--color-ink)]"
+                defaultValue="active"
+                name="status"
+              >
+                <option value="active">active</option>
+                <option value="inactive">inactive</option>
+                <option value="suspended">suspended</option>
+              </select>
+            </label>
+
+            <label className="form-field">
+              <span>Observações administrativas</span>
+              <textarea
+                className="min-h-28"
+                name="notes"
+                placeholder="Contexto da concessão, grupo, observação interna ou referência operacional."
+              />
+            </label>
+
+            <ActionFeedback state={grantState} />
+
+            <button className="primary-button" disabled={isGranting} type="submit">
+              {isGranting ? "Salvando..." : "Conceder vínculo de associado"}
+            </button>
+          </form>
+        </article>
+      </section>
+
+      <section className="grid gap-5">
+        <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
+          <p className="section-eyebrow">Concessões por email</p>
+          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
+            Quem já foi autorizado a entrar como associado
+          </h3>
+          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
+            Esta lista usa `associate_bootstrap_grants` para registrar a
+            autorização por email e preparar o primeiro acesso do associado.
+          </p>
+
+          <div className="mt-6 grid gap-4">
+            {safeBootstrapGrants.length ? (
+              safeBootstrapGrants.map((grant) => (
+                <div
+                  className="rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,255,255,0.7)] p-5"
+                  key={grant.id}
+                >
+                  <p className="text-base font-semibold text-[var(--color-green-deep)]">
+                    {grant.email}
+                  </p>
+                  <div className="mt-4 flex flex-wrap gap-3">
+                    <InfoChip label="Grant" value={grant.status} />
+                    <InfoChip label="Vínculo previsto" value={grant.membershipStatus} />
+                    <InfoChip
+                      label="Claim"
+                      value={grant.claimedAt ? formatDateTime(grant.claimedAt) : "Ainda não"}
+                    />
+                  </div>
+                  {grant.notes ? (
+                    <p className="mt-4 text-sm leading-7 text-[var(--color-muted)]">
+                      {grant.notes}
+                    </p>
+                  ) : null}
+                </div>
+              ))
+            ) : (
+              <p className="text-sm leading-7 text-[var(--color-muted)]">
+                Nenhuma autorização de associado por email foi registrada até o
+                momento.
+              </p>
+            )}
+          </div>
+        </article>
+      </section>
+    </div>
+  );
+}
+
+function AssociateMembershipRow({
+  membership,
+}: {
+  membership: AdminAssociateMembershipRecord;
+}) {
+  const [state, action, isPending] = useActionState(
+    updateAssociateMembership,
+    initialState,
+  );
+
+  return (
+    <form
+      action={action}
+      className="min-w-[72rem] border-b border-[rgba(23,54,45,0.08)] bg-[rgba(255,255,255,0.7)] px-5 py-5 last:border-b-0"
+    >
+      <input name="membershipId" type="hidden" value={membership.id} />
+
+      <div className="grid gap-4 lg:grid-cols-[1.2fr_1.25fr_0.85fr_1fr_1fr_1.2fr] lg:items-start">
+        <div className="max-w-2xl">
+          <p className="text-base font-semibold text-[var(--color-green-deep)]">
+            {membership.profile.fullName || "Sem nome informado"}
+          </p>
+          <p className="mt-3 text-xs uppercase tracking-[0.18em] text-[var(--color-red)]">
+            Concedido em {formatDateTime(membership.grantedAt)}
+          </p>
+        </div>
+
+        <div className="text-sm leading-7 text-[var(--color-muted)]">
+          {membership.profile.email}
+        </div>
+
+        <div className="text-sm leading-7 text-[var(--color-muted)]">
+          {membership.profileSnapshot?.category || "Nao definida"}
+        </div>
+
+        <div className="text-sm leading-7 text-[var(--color-muted)]">
+          {membership.profileSnapshot?.phone || "Nao informado"}
+        </div>
+
+        <div className="grid gap-3">
+          <label className="form-field">
+            <span className="lg:sr-only">Status</span>
+            <select
+              className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-[rgba(255,250,243,0.88)] px-4 py-3 text-[var(--color-ink)]"
+              defaultValue={membership.status}
+              name="status"
+            >
+              <option value="active">active</option>
+              <option value="inactive">inactive</option>
+              <option value="suspended">suspended</option>
+            </select>
+          </label>
+          <ActionFeedback state={state} />
+        </div>
+
+        <div className="grid gap-3">
+          <label className="form-field">
+            <span className="lg:sr-only">Observações administrativas</span>
+            <textarea
+              className="min-h-24"
+              defaultValue={membership.notes || ""}
+              name="notes"
+              placeholder="Observações internas sobre este vínculo."
+            />
+          </label>
+          <button className="secondary-button" disabled={isPending} type="submit">
+            {isPending ? "Salvando..." : "Atualizar vínculo"}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+function ActionFeedback({ state }: { state: AdminAssociatesActionState }) {
+  if (state.error) {
+    return <p className="text-sm font-medium text-[var(--color-red-deep)]">{state.error}</p>;
+  }
+
+  if (state.success) {
+    return (
+      <p className="text-sm font-medium text-[var(--color-green-deep)]">{state.success}</p>
+    );
+  }
+
+  return null;
+}
+
+function InfoChip({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="rounded-full border border-[rgba(23,54,45,0.12)] bg-[rgba(255,250,243,0.82)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--color-green-deep)]">
+      {label}: {value}
+    </span>
+  );
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}

--- a/src/components/admin-associates-manager.tsx
+++ b/src/components/admin-associates-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useDeferredValue, useEffect, useState } from "react";
+import { useActionState, useDeferredValue, useState } from "react";
 import {
   grantAssociateAccess,
   updateAssociateMembership,
@@ -58,12 +58,6 @@ export function AdminAssociatesManager({
     (currentPage - 1) * PAGE_SIZE,
     currentPage * PAGE_SIZE,
   );
-
-  useEffect(() => {
-    if (page !== currentPage) {
-      setPage(currentPage);
-    }
-  }, [currentPage, page]);
 
   return (
     <div className="grid gap-6">

--- a/src/components/admin-permissions-manager.tsx
+++ b/src/components/admin-permissions-manager.tsx
@@ -19,7 +19,6 @@ const initialState: AdminPermissionsActionState = {};
 
 type AdminPermissionsManagerProps = {
   bootstrapGrants: AdminBootstrapGrantRecord[];
-  currentAdminEmail?: string;
   currentAdminProfileId: string;
   currentAdminRole: string;
   eligibleProfiles: EligibleAdminProfileRecord[];
@@ -28,7 +27,6 @@ type AdminPermissionsManagerProps = {
 
 export function AdminPermissionsManager({
   bootstrapGrants,
-  currentAdminEmail,
   currentAdminProfileId,
   currentAdminRole,
   eligibleProfiles,

--- a/src/components/associate-area-manager.tsx
+++ b/src/components/associate-area-manager.tsx
@@ -65,7 +65,6 @@ type CepLookupState =
   | { status: "error"; message: string };
 
 type AssociateAreaManagerProps = {
-  accessEmail?: string;
   authMethods: AssociateAuthMethods;
   profile: AssociateProfileRecord;
 };
@@ -79,7 +78,6 @@ Me comprometo a devolver o mencionado bem em perfeito estado de conservação, c
 Em caso de extravio ou danos que provoquem a perda total ou parcial do bem, fico obrigado a ressarcir a Associação Alemã de Juiz de Fora/MG dos prejuízos ocasionados.`;
 
 export function AssociateAreaManager({
-  accessEmail,
   authMethods,
   profile,
 }: AssociateAreaManagerProps) {
@@ -95,6 +93,9 @@ export function AssociateAreaManager({
   const [photoObjectUrl, setPhotoObjectUrl] = useState<string | null>(null);
   const [photoState, setPhotoState] = useState<PhotoState>({});
   const [isSavingPassword, setIsSavingPassword] = useState(false);
+  const [isCardModalOpen, setIsCardModalOpen] = useState(false);
+  const [cardPreviewUrl, setCardPreviewUrl] = useState<string | null>(null);
+  const [isGeneratingCardPreview, setIsGeneratingCardPreview] = useState(false);
   const [cepLookupState, setCepLookupState] = useState<CepLookupState>({
     status: "idle",
   });
@@ -125,6 +126,24 @@ export function AssociateAreaManager({
     value: AssociateDraft[K],
   ) {
     setDraft((current) => ({ ...current, [key]: value }));
+  }
+
+  async function handleOpenCardModal() {
+    setIsGeneratingCardPreview(true);
+
+    const previewUrl = await createAssociateCardPngDataUrl({
+      birthDate: formatDate(draft.birthDate),
+      category: draft.category || "Não informada",
+      cpf: draft.cpf || "Não informado",
+      fullName: draft.fullName || "Nome em atualização",
+      nationality: draft.nationality || "Não informada",
+      photoUrl: draft.photoUrl,
+      profileId: profile.profileId,
+    });
+
+    setCardPreviewUrl(previewUrl);
+    setIsGeneratingCardPreview(false);
+    setIsCardModalOpen(true);
   }
 
   function handleCepChange(value: string) {
@@ -328,16 +347,14 @@ export function AssociateAreaManager({
             <p className="section-eyebrow text-[0.88rem]">
               Dados do Associado
             </p>
-            <div className="mt-4 flex justify-end">
-              <AssociateMiniCard
-                category={draft.category || "Não informada"}
-                cpf={draft.cpf || "Não informado"}
-                fullName={draft.fullName || "Nome em atualização"}
-                nationality={draft.nationality || "Não informada"}
-                photoUrl={draft.photoUrl}
-                profileId={profile.profileId}
-                birthDate={formatDate(draft.birthDate)}
-              />
+            <div className="-mt-8 flex justify-end">
+              <button
+                className="secondary-button"
+                onClick={handleOpenCardModal}
+                type="button"
+              >
+                {isGeneratingCardPreview ? "Gerando prévia..." : "Visualizar carteirinha"}
+              </button>
             </div>
 
             <div className="mt-6 grid gap-6">
@@ -831,36 +848,68 @@ export function AssociateAreaManager({
           </article>
         </section>
       </section>
+
+      {isCardModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,23,20,0.62)] px-4 py-6">
+          <div className="relative w-full max-w-[54rem] rounded-[2rem] border border-white/60 bg-[rgba(255,250,243,0.96)] p-6 shadow-[0_24px_80px_rgba(9,28,22,0.28)] backdrop-blur">
+            <button
+              aria-label="Fechar prévia da carteirinha"
+              className="absolute right-4 top-4 grid h-10 w-10 place-items-center rounded-full border border-[rgba(23,54,45,0.12)] bg-white text-lg text-[var(--color-green-deep)] transition hover:bg-[rgba(255,250,243,0.92)]"
+              onClick={() => setIsCardModalOpen(false)}
+              type="button"
+            >
+              ×
+            </button>
+
+            <div className="flex justify-center">
+              {cardPreviewUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  alt={`Prévia da carteirinha de ${draft.fullName || "associado"}`}
+                  className="h-auto w-full max-w-[46rem] rounded-[1.25rem] shadow-[0_18px_48px_rgba(16,46,37,0.18)]"
+                  src={cardPreviewUrl}
+                />
+              ) : (
+                <div className="grid min-h-[18rem] w-full max-w-[46rem] place-items-center rounded-[1.25rem] border border-[rgba(23,54,45,0.12)] bg-[rgba(255,250,243,0.72)] text-sm text-[var(--color-muted)]">
+                  Não foi possível gerar a prévia da carteirinha.
+                </div>
+              )}
+            </div>
+
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                className="secondary-button"
+                onClick={() => setIsCardModalOpen(false)}
+                type="button"
+              >
+                Fechar
+              </button>
+              <button
+                className="primary-button"
+                onClick={() =>
+                  downloadAssociateCardPng({
+                    birthDate: formatDate(draft.birthDate),
+                    category: draft.category || "Não informada",
+                    cpf: draft.cpf || "Não informado",
+                    fullName: draft.fullName || "Nome em atualização",
+                    nationality: draft.nationality || "Não informada",
+                    photoUrl: draft.photoUrl,
+                    profileId: profile.profileId,
+                  })
+                }
+                type="button"
+              >
+                Baixar carteirinha em PNG
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }
 
-function CardDataBox({
-  label,
-  value,
-  wide,
-}: {
-  label: string;
-  value: string;
-  wide?: boolean;
-}) {
-  return (
-    <div
-      className={`border-b border-[rgba(23,59,47,0.16)] px-0 pb-3 pt-3 ${
-        wide ? "sm:col-span-2 xl:col-span-2" : ""
-      }`}
-    >
-      <p className="text-[0.64rem] font-black uppercase tracking-[0.22em] text-[var(--color-muted)]">
-        {label}
-      </p>
-      <p className="mt-2 text-[0.98rem] font-extrabold leading-6 text-[var(--color-green-deep)]">
-        {value}
-      </p>
-    </div>
-  );
-}
-
-function AssociateMiniCard({
+async function downloadAssociateCardPng({
   birthDate,
   category,
   cpf,
@@ -877,233 +926,160 @@ function AssociateMiniCard({
   photoUrl: string | null;
   profileId: string;
 }) {
-  async function handleDownloadCard() {
-    const canvas = document.createElement("canvas");
-    const width = 760;
-    const height = 480;
-    canvas.width = width;
-    canvas.height = height;
+  const dataUrl = await createAssociateCardPngDataUrl({
+    birthDate,
+    category,
+    cpf,
+    fullName,
+    nationality,
+    photoUrl,
+    profileId,
+  });
 
-    const context = canvas.getContext("2d");
-
-    if (!context) {
-      return;
-    }
-
-    context.fillStyle = "#efe1c9";
-    context.fillRect(0, 0, width, height);
-
-    drawRoundedRect(context, 14, 14, width - 28, height - 28, 34);
-
-    const gradient = context.createLinearGradient(0, 0, width, height);
-    gradient.addColorStop(0, "#fffaf2");
-    gradient.addColorStop(1, "#f8efe1");
-    context.fillStyle = gradient;
-    context.fill();
-
-    context.save();
-    drawRoundedRect(context, 14, 14, width - 28, height - 28, 34);
-    context.clip();
-    context.fillStyle = "#173b2f";
-    context.fillRect(14, 14, 258, height - 28);
-    context.restore();
-
-    context.strokeStyle = "rgba(23,59,47,0.12)";
-    context.lineWidth = 1;
-    drawRoundedRect(context, 24, 24, width - 48, height - 48, 26);
-    context.stroke();
-
-    context.fillStyle = "rgba(255,247,237,0.96)";
-    context.beginPath();
-    context.arc(83, 90, 34, 0, Math.PI * 2);
-    context.fill();
-
-    context.fillStyle = "#173b2f";
-    context.font = '700 30px "Cormorant Garamond", Georgia, serif';
-    context.textAlign = "center";
-    context.fillText("AAJF", 83, 99);
-
-    context.textAlign = "left";
-    context.fillStyle = "rgba(255,247,237,0.84)";
-    context.font = '700 12px "Geist", system-ui, sans-serif';
-    drawMultilineText(
-      context,
-      "ASSOCIAÇÃO CULTURAL E RECREATIVA BRASIL-ALEMANHA",
-      48,
-      156,
-      165,
-      18,
-    );
-
-    drawMiniQr(context, 48, 330, 84);
-    context.fillStyle = "rgba(255,247,237,0.74)";
-    context.font = '500 11px "Geist", system-ui, sans-serif';
-    drawMultilineText(
-      context,
-      "Documento digital de identificação do associado.",
-      48,
-      430,
-      160,
-      16,
-    );
-
-    context.fillStyle = "#d8b45f";
-    context.font = '800 12px "Geist", system-ui, sans-serif';
-    context.fillText("CARTEIRA DO ASSOCIADO", 316, 72);
-
-    context.fillStyle = "#5f7268";
-    context.font = '800 12px "Geist", system-ui, sans-serif';
-    context.fillText("ASSOCIADO", 316, 114);
-
-    context.textAlign = "right";
-    context.fillText(formatAssociateCardId(profileId), 704, 72);
-    context.textAlign = "left";
-
-    context.fillStyle = "#173b2f";
-    context.font = '400 68px "Cormorant Garamond", Georgia, serif';
-    drawMultilineText(context, fullName, 316, 182, 290, 66);
-
-    await drawPhotoBlock(context, photoUrl, 610, 92, 130, 160);
-
-    drawCardField(context, "Categoria", category, 316, 288, 150);
-    drawCardField(context, "CPF", cpf, 478, 288, 126);
-    drawCardField(context, "Nascimento", birthDate, 622, 288, 82);
-    drawCardField(context, "Naturalidade", nationality, 316, 370, 288);
-    drawCardField(context, "Validade", "31/12/2026", 622, 370, 82);
-
-    context.strokeStyle = "rgba(23,59,47,0.22)";
-    context.setLineDash([4, 5]);
-    context.beginPath();
-    context.moveTo(316, 408);
-    context.lineTo(704, 408);
-    context.stroke();
-    context.setLineDash([]);
-
-    drawStatusPill(context, 316, 430, "Associado ativo");
-
-    context.fillStyle = "#5f7268";
-    context.font = '500 11px "Geist", system-ui, sans-serif';
-    context.textAlign = "right";
-    drawMultilineText(
-      context,
-      "Uso interno da Associação Alemã de Juiz de Fora. Validação mediante QR Code.",
-      704,
-      438,
-      180,
-      16,
-      "right",
-    );
-
-    const downloadLink = document.createElement("a");
-    downloadLink.href = canvas.toDataURL("image/png");
-    downloadLink.download = `${slugifyFileName(fullName || "associado")}-carteirinha.png`;
-    downloadLink.click();
+  if (!dataUrl) {
+    return;
   }
 
-  return (
-    <button
-      className="group block w-[18rem] cursor-pointer rounded-[1rem] bg-transparent text-left transition-transform hover:-translate-y-1"
-      onClick={handleDownloadCard}
-      title="Clique para baixar a carteirinha em PNG"
-      type="button"
-    >
-      <article className="relative w-[18rem] overflow-hidden rounded-[1rem] border border-white/85 bg-[linear-gradient(135deg,#fffaf2,var(--color-paper))] shadow-[0_14px_32px_rgba(16,46,37,0.14)]">
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(115deg,rgba(255,255,255,0.42),transparent_30%)]" />
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,var(--color-green-deep)_0_34%,transparent_34%),radial-gradient(circle_at_88%_90%,rgba(185,28,28,0.12),transparent_30%),radial-gradient(circle_at_55%_0%,rgba(216,180,95,0.14),transparent_34%)]" />
-      <div className="pointer-events-none absolute inset-[4px] rounded-[0.8rem] border border-[rgba(23,59,47,0.12)]" />
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(118deg,transparent_0_38%,rgba(255,255,255,0.32)_47%,transparent_58%)] opacity-50" />
-
-      <div className="relative z-[1] grid aspect-[1.586/1] grid-cols-[4.2rem_minmax(0,1fr)]">
-        <aside className="flex flex-col justify-between px-2.5 py-2.5 text-[var(--color-paper)]">
-          <div>
-            <div className="grid h-6 w-6 place-items-center rounded-full bg-[rgba(255,247,237,0.96)] text-[0.48rem] font-bold text-[var(--color-green-deep)]">
-              <span className="font-heading">AAJF</span>
-            </div>
-            <p className="mt-2 text-[0.28rem] uppercase tracking-[0.14em] text-[rgba(255,247,237,0.82)]">
-              Associação Cultural e Recreativa Brasil-Alemanha
-            </p>
-          </div>
-
-          <div>
-            <div className="grid h-5 w-5 place-items-center rounded-[0.35rem] border-[3px] border-[var(--color-paper)] bg-[linear-gradient(90deg,var(--color-green-deep)_3px,transparent_3px)_0_0/6px_6px,linear-gradient(var(--color-green-deep)_3px,transparent_3px)_0_0/6px_6px,#fff7ed]" />
-            <p className="mt-2 text-[0.28rem] leading-[1.25] text-[rgba(255,247,237,0.74)]">
-              Documento digital do associado.
-            </p>
-          </div>
-        </aside>
-
-        <section className="flex flex-col justify-between px-2.5 py-2.5">
-          <div>
-            <header className="flex items-start justify-between gap-2">
-              <p className="text-[0.28rem] font-extrabold uppercase tracking-[0.18em] text-[var(--color-gold-strong)]">
-                Carteira do Associado
-              </p>
-              <span className="whitespace-nowrap text-[0.3rem] font-extrabold tracking-[0.08em] text-[var(--color-muted)]">
-                {formatAssociateCardId(profileId)}
-              </span>
-            </header>
-
-            <div className="mt-1.5 flex items-start justify-between gap-2">
-              <div>
-                <p className="mb-1 text-[0.3rem] font-extrabold uppercase tracking-[0.14em] text-[var(--color-muted)]">
-                  Associado
-                </p>
-                <h3 className="max-w-[6.5rem] font-heading text-[1.08rem] leading-[0.92] tracking-[-0.04em] text-[var(--color-green-deep)]">
-                  {fullName}
-                </h3>
-              </div>
-
-              <div className="grid h-11 w-9 flex-none place-items-center overflow-hidden rounded-[0.6rem] border border-[rgba(23,59,47,0.18)] bg-[linear-gradient(135deg,#e8dfd1,#fffaf2)] shadow-[0_8px_18px_rgba(23,59,47,0.1),inset_0_0_0_2px_rgba(255,255,255,0.7)]">
-                {photoUrl ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    alt={`Foto de ${fullName}`}
-                    className="h-full w-full object-cover"
-                    src={photoUrl}
-                  />
-                ) : (
-                  <div className="px-1 text-center text-[0.24rem] font-black uppercase tracking-[0.08em] text-[var(--color-muted)]">
-                    Sem foto
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <section className="mt-2.5 grid grid-cols-2 gap-x-2 gap-y-1.5">
-              <MiniCardDataBox label="Categoria" value={category} />
-              <MiniCardDataBox label="CPF" value={cpf} />
-              <MiniCardDataBox label="Nascimento" value={birthDate} />
-              <MiniCardDataBox label="Naturalidade" value={nationality} />
-            </section>
-          </div>
-
-          <footer className="mt-2 flex items-end justify-between gap-2 border-t border-dashed border-[rgba(23,59,47,0.16)] pt-1.5">
-            <div className="inline-flex items-center gap-1 rounded-full border border-[rgba(23,59,47,0.12)] bg-[rgba(23,59,47,0.08)] px-1.5 py-0.5 text-[0.28rem] font-black text-[var(--color-green-deep)]">
-              <span className="h-1 w-1 rounded-full bg-[#22c55e] shadow-[0_0_8px_rgba(34,197,94,0.85)]" />
-              Ativo
-            </div>
-            <p className="max-w-[4.25rem] text-right text-[0.24rem] leading-[1.2] text-[var(--color-muted)]">
-              Uso interno da AAJF.
-            </p>
-          </footer>
-        </section>
-      </div>
-      </article>
-    </button>
-  );
+  const downloadLink = document.createElement("a");
+  downloadLink.href = dataUrl;
+  downloadLink.download = `${slugifyFileName(fullName || "associado")}-carteirinha.png`;
+  downloadLink.click();
 }
 
-function MiniCardDataBox({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="border-b border-[rgba(23,59,47,0.12)] pb-1">
-      <p className="text-[0.22rem] font-black uppercase tracking-[0.12em] text-[var(--color-muted)]">
-        {label}
-      </p>
-      <p className="mt-0.5 text-[0.34rem] font-extrabold leading-[1.25] text-[var(--color-green-deep)]">
-        {value}
-      </p>
-    </div>
+async function createAssociateCardPngDataUrl({
+  birthDate,
+  category,
+  cpf,
+  fullName,
+  nationality,
+  photoUrl,
+  profileId,
+}: {
+  birthDate: string;
+  category: string;
+  cpf: string;
+  fullName: string;
+  nationality: string;
+  photoUrl: string | null;
+  profileId: string;
+}) {
+  const canvas = document.createElement("canvas");
+  const width = 760;
+  const height = 480;
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    return null;
+  }
+
+  context.fillStyle = "#efe1c9";
+  context.fillRect(0, 0, width, height);
+
+  drawRoundedRect(context, 14, 14, width - 28, height - 28, 34);
+
+  const gradient = context.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, "#fffaf2");
+  gradient.addColorStop(1, "#f8efe1");
+  context.fillStyle = gradient;
+  context.fill();
+
+  context.save();
+  drawRoundedRect(context, 14, 14, width - 28, height - 28, 34);
+  context.clip();
+  context.fillStyle = "#173b2f";
+  context.fillRect(14, 14, 258, height - 28);
+  context.restore();
+
+  context.strokeStyle = "rgba(23,59,47,0.12)";
+  context.lineWidth = 1;
+  drawRoundedRect(context, 24, 24, width - 48, height - 48, 26);
+  context.stroke();
+
+  context.fillStyle = "rgba(255,247,237,0.96)";
+  context.beginPath();
+  context.arc(83, 90, 34, 0, Math.PI * 2);
+  context.fill();
+
+  context.fillStyle = "#173b2f";
+  context.font = '700 30px "Cormorant Garamond", Georgia, serif';
+  context.textAlign = "center";
+  context.fillText("AAJF", 83, 99);
+
+  context.textAlign = "left";
+  context.fillStyle = "rgba(255,247,237,0.84)";
+  context.font = '700 12px "Geist", system-ui, sans-serif';
+  drawMultilineText(
+    context,
+    "ASSOCIAÇÃO CULTURAL E RECREATIVA BRASIL-ALEMANHA",
+    48,
+    156,
+    165,
+    18,
   );
+
+  drawMiniQr(context, 48, 330, 84);
+  context.fillStyle = "rgba(255,247,237,0.74)";
+  context.font = '500 11px "Geist", system-ui, sans-serif';
+  drawMultilineText(
+    context,
+    "Documento digital de identificação do associado.",
+    48,
+    430,
+    160,
+    16,
+  );
+
+  context.fillStyle = "#d8b45f";
+  context.font = '800 12px "Geist", system-ui, sans-serif';
+  context.fillText("CARTEIRA DO ASSOCIADO", 316, 72);
+
+  context.fillStyle = "#5f7268";
+  context.font = '800 12px "Geist", system-ui, sans-serif';
+  context.fillText("ASSOCIADO", 316, 114);
+
+  context.textAlign = "right";
+  context.fillText(formatAssociateCardId(profileId), 704, 72);
+  context.textAlign = "left";
+
+  context.fillStyle = "#173b2f";
+  context.font = '400 68px "Cormorant Garamond", Georgia, serif';
+  drawMultilineText(context, fullName, 316, 182, 290, 66);
+
+  await drawPhotoBlock(context, photoUrl, 610, 92, 130, 160);
+
+  drawCardField(context, "Categoria", category, 316, 288, 150);
+  drawCardField(context, "CPF", cpf, 478, 288, 126);
+  drawCardField(context, "Nascimento", birthDate, 622, 288, 82);
+  drawCardField(context, "Naturalidade", nationality, 316, 370, 288);
+  drawCardField(context, "Validade", "31/12/2026", 622, 370, 82);
+
+  context.strokeStyle = "rgba(23,59,47,0.22)";
+  context.setLineDash([4, 5]);
+  context.beginPath();
+  context.moveTo(316, 408);
+  context.lineTo(704, 408);
+  context.stroke();
+  context.setLineDash([]);
+
+  drawStatusPill(context, 316, 430, "Associado ativo");
+
+  context.fillStyle = "#5f7268";
+  context.font = '500 11px "Geist", system-ui, sans-serif';
+  context.textAlign = "right";
+  drawMultilineText(
+    context,
+    "Uso interno da Associação Alemã de Juiz de Fora. Validação mediante QR Code.",
+    704,
+    438,
+    180,
+    16,
+    "right",
+  );
+
+  return canvas.toDataURL("image/png");
 }
 
 async function drawPhotoBlock(

--- a/src/components/associate-area-manager.tsx
+++ b/src/components/associate-area-manager.tsx
@@ -1,0 +1,1566 @@
+"use client";
+
+import { useActionState, useEffect, useState } from "react";
+import {
+  saveAssociateProfile,
+  type AssociateProfileActionState,
+} from "@/app/associado/actions";
+import { createBrowserSupabaseClient } from "@/lib/supabase/browser";
+import {
+  associatePhotoAcceptedMimeTypes,
+  associatePhotoMaxFileSizeInBytes,
+  associateCategoryOptions,
+  nationalityOptions,
+  type AssociateAuthMethods,
+  type AssociateCategory,
+  type Nationality,
+  type AssociateProfileRecord,
+} from "@/lib/supabase/associate-profile-shared";
+
+type DependentDraft = {
+  birthDate: string;
+  category: AssociateCategory | "";
+  cpf: string;
+  fullName: string;
+  id: string;
+  nationality: Nationality | "";
+  rg: string;
+};
+
+type AssociateDraft = {
+  addressCity: string;
+  addressComplement: string;
+  addressNeighborhood: string;
+  addressNumber: string;
+  addressState: string;
+  addressStreet: string;
+  birthDate: string;
+  category: AssociateCategory | "";
+  cep: string;
+  cpf: string;
+  dependents: DependentDraft[];
+  email: string;
+  fullName: string;
+  nationality: Nationality | "";
+  observation: string;
+  phone: string;
+  photoUrl: string | null;
+  rg: string;
+  termAccepted: boolean;
+};
+
+type PasswordState = {
+  error?: string;
+  success?: string;
+};
+
+type PhotoState = {
+  error?: string;
+};
+
+type CepLookupState =
+  | { status: "idle" }
+  | { status: "loading"; message: string }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string };
+
+type AssociateAreaManagerProps = {
+  accessEmail?: string;
+  authMethods: AssociateAuthMethods;
+  profile: AssociateProfileRecord;
+};
+
+const initialSaveState: AssociateProfileActionState = {};
+
+const TERM_TEXT = `Por meio deste instrumento, declaro me responsabilizar pela guarda e conservação do TRAJE FOLCLÓRICO do GRUPO DE DANÇAS FOLCLÓRICAS GERMÂNICAS SCHMETTERLING de propriedade da ASSOCIAÇÃO ALEMÃ DE JUIZ DE FORA/MG, inscrita no CNPJ 73.627.960/0001-50 pelo tempo que estiver associado a entidade e integrar o referido grupo.
+
+Me comprometo a devolver o mencionado bem em perfeito estado de conservação, como atualmente se encontra.
+
+Em caso de extravio ou danos que provoquem a perda total ou parcial do bem, fico obrigado a ressarcir a Associação Alemã de Juiz de Fora/MG dos prejuízos ocasionados.`;
+
+export function AssociateAreaManager({
+  accessEmail,
+  authMethods,
+  profile,
+}: AssociateAreaManagerProps) {
+  const [saveState, saveAction, isSavingProfile] = useActionState(
+    saveAssociateProfile,
+    initialSaveState,
+  );
+  const [accountMethods, setAccountMethods] = useState(authMethods);
+  const [draft, setDraft] = useState<AssociateDraft>(() => createDraft(profile));
+  const [passwordState, setPasswordState] = useState<PasswordState>({});
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [photoObjectUrl, setPhotoObjectUrl] = useState<string | null>(null);
+  const [photoState, setPhotoState] = useState<PhotoState>({});
+  const [isSavingPassword, setIsSavingPassword] = useState(false);
+  const [cepLookupState, setCepLookupState] = useState<CepLookupState>({
+    status: "idle",
+  });
+  const [lastResolvedCep, setLastResolvedCep] = useState<string>(
+    normalizeCep(profile.cep),
+  );
+
+  useEffect(() => {
+    setDraft(createDraft(profile));
+    setLastResolvedCep(normalizeCep(profile.cep));
+    setCepLookupState({ status: "idle" });
+  }, [profile]);
+
+  useEffect(() => {
+    setAccountMethods(authMethods);
+  }, [authMethods]);
+
+  useEffect(() => {
+    return () => {
+      if (photoObjectUrl) {
+        URL.revokeObjectURL(photoObjectUrl);
+      }
+    };
+  }, [photoObjectUrl]);
+
+  function updateDraft<K extends keyof AssociateDraft>(
+    key: K,
+    value: AssociateDraft[K],
+  ) {
+    setDraft((current) => ({ ...current, [key]: value }));
+  }
+
+  function handleCepChange(value: string) {
+    updateDraft("cep", formatCep(value));
+
+    if (normalizeCep(value) !== lastResolvedCep) {
+      setCepLookupState({ status: "idle" });
+    }
+  }
+
+  function handleDependentChange<K extends keyof DependentDraft>(
+    dependentId: string,
+    key: K,
+    value: DependentDraft[K],
+  ) {
+    setDraft((current) => ({
+      ...current,
+      dependents: current.dependents.map((dependent) =>
+        dependent.id === dependentId ? { ...dependent, [key]: value } : dependent,
+      ),
+    }));
+  }
+
+  function addDependent() {
+    setDraft((current) => ({
+      ...current,
+      dependents: [
+        ...current.dependents,
+        {
+          birthDate: "",
+          category: "",
+          cpf: "",
+          fullName: "",
+          id: createClientId(),
+          nationality: "",
+          rg: "",
+        },
+      ],
+    }));
+  }
+
+  function removeDependent(dependentId: string) {
+    setDraft((current) => ({
+      ...current,
+      dependents: current.dependents.filter((dependent) => dependent.id !== dependentId),
+    }));
+  }
+
+  function handlePhotoChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (!associatePhotoAcceptedMimeTypes.includes(file.type)) {
+      setPhotoState({
+        error: "Use uma imagem JPG, PNG ou WEBP para a foto do associado.",
+      });
+      event.target.value = "";
+      return;
+    }
+
+    if (file.size > associatePhotoMaxFileSizeInBytes) {
+      setPhotoState({
+        error: "A foto deve ter no máximo 5 MB para manter o cadastro leve.",
+      });
+      event.target.value = "";
+      return;
+    }
+
+    if (photoObjectUrl) {
+      URL.revokeObjectURL(photoObjectUrl);
+    }
+
+    const nextObjectUrl = URL.createObjectURL(file);
+    setPhotoState({});
+    setPhotoObjectUrl(nextObjectUrl);
+    updateDraft("photoUrl", nextObjectUrl);
+  }
+
+  async function handlePasswordSave(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (password.length < 8) {
+      setPasswordState({ error: "A senha precisa ter pelo menos 8 caracteres." });
+      return;
+    }
+
+    if (password !== passwordConfirmation) {
+      setPasswordState({ error: "A confirmação de senha não confere." });
+      return;
+    }
+
+    setPasswordState({});
+    setIsSavingPassword(true);
+
+    const supabase = createBrowserSupabaseClient();
+    const { error } = await supabase.auth.updateUser({ password });
+
+    if (error) {
+      setPasswordState({ error: error.message });
+      setIsSavingPassword(false);
+      return;
+    }
+
+    setPassword("");
+    setPasswordConfirmation("");
+    setAccountMethods((current) => ({ ...current, hasPassword: true }));
+    setPasswordState({
+      success: "Senha atualizada com sucesso para os próximos acessos.",
+    });
+    setIsSavingPassword(false);
+  }
+
+  async function handleCepLookup() {
+    const cep = normalizeCep(draft.cep);
+
+    if (!cep) {
+      setCepLookupState({ status: "idle" });
+      return;
+    }
+
+    if (!isValidCep(cep)) {
+      setCepLookupState({
+        status: "error",
+        message: "Informe um CEP com 8 dígitos para buscar o endereço.",
+      });
+      return;
+    }
+
+    if (cep === lastResolvedCep) {
+      return;
+    }
+
+    setCepLookupState({
+      status: "loading",
+      message: "Consultando o endereço para o CEP informado...",
+    });
+
+    try {
+      const response = await fetch(`https://viacep.com.br/ws/${cep}/json/`, {
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        throw new Error("cep-lookup-failed");
+      }
+
+      const payload = (await response.json()) as ViaCepResponse;
+
+      if (payload.erro) {
+        setCepLookupState({
+          status: "error",
+          message: "CEP não encontrado. Confira o número informado.",
+        });
+        return;
+      }
+
+      setDraft((current) => ({
+        ...current,
+        addressCity: payload.localidade || current.addressCity,
+        addressNeighborhood: payload.bairro || current.addressNeighborhood,
+        addressState: payload.uf || current.addressState,
+        addressStreet: payload.logradouro || current.addressStreet,
+      }));
+      setLastResolvedCep(cep);
+      setCepLookupState({
+        status: "success",
+        message:
+          "Endereço preenchido automaticamente. Revise número e complemento antes de salvar.",
+      });
+    } catch {
+      setCepLookupState({
+        status: "error",
+        message:
+          "Não foi possível consultar o CEP agora. Você pode continuar preenchendo os campos manualmente.",
+      });
+    }
+  }
+
+  const dependentPayload = JSON.stringify(
+    draft.dependents.map((dependent) => ({
+      birthDate: dependent.birthDate,
+      category: dependent.category || null,
+      cpf: dependent.cpf || null,
+      fullName: dependent.fullName,
+      id: dependent.id,
+      nationality: dependent.nationality || null,
+      rg: dependent.rg || null,
+    })),
+  );
+
+  return (
+    <div className="grid gap-6">
+      <section className="grid gap-5">
+        <form action={saveAction} className="grid gap-5">
+          <input name="dependentsPayload" type="hidden" value={dependentPayload} />
+
+          <article className="soft-card rounded-[2rem] p-8 sm:p-10">
+            <p className="section-eyebrow text-[0.88rem]">
+              Dados do Associado
+            </p>
+            <div className="mt-4 flex justify-end">
+              <AssociateMiniCard
+                category={draft.category || "Não informada"}
+                cpf={draft.cpf || "Não informado"}
+                fullName={draft.fullName || "Nome em atualização"}
+                nationality={draft.nationality || "Não informada"}
+                photoUrl={draft.photoUrl}
+                profileId={profile.profileId}
+                birthDate={formatDate(draft.birthDate)}
+              />
+            </div>
+
+            <div className="mt-6 grid gap-6">
+              <div className="rounded-[1.6rem] border border-[rgba(23,54,45,0.1)] bg-white/70 p-6">
+                <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_minmax(21rem,22rem)] xl:items-start">
+                  <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-3">
+                    <TextField
+                      label="Nome completo"
+                      name="fullName"
+                      onChange={(value) => updateDraft("fullName", value)}
+                      required
+                      value={draft.fullName}
+                    />
+                    <ReadOnlyField label="Email" value={draft.email} />
+                    <SelectField
+                      label="Categoria"
+                      name="category"
+                      onChange={(value) =>
+                        updateDraft("category", value as AssociateCategory | "")
+                      }
+                      options={associateCategoryOptions}
+                      placeholder="Selecione uma categoria"
+                      required
+                      value={draft.category}
+                    />
+                    <TextField
+                      label="CPF"
+                      name="cpf"
+                      inputMode="numeric"
+                      maxLength={14}
+                      onChange={(value) => updateDraft("cpf", formatCpf(value))}
+                      required
+                      value={draft.cpf}
+                    />
+                    <TextField
+                      label="RG"
+                      name="rg"
+                      onChange={(value) => updateDraft("rg", value)}
+                      required
+                      value={draft.rg}
+                    />
+                    <TextField
+                      label="Telefone com DDD"
+                      name="phone"
+                      inputMode="numeric"
+                      maxLength={15}
+                      onChange={(value) => updateDraft("phone", formatPhone(value))}
+                      required
+                      value={draft.phone}
+                    />
+                    <DateField
+                      label="Data de nascimento"
+                      name="birthDate"
+                      onChange={(value) => updateDraft("birthDate", value)}
+                      required
+                      value={draft.birthDate}
+                    />
+                    <SelectField
+                      label="Naturalidade"
+                      name="nationality"
+                      onChange={(value) =>
+                        updateDraft("nationality", value as Nationality | "")
+                      }
+                      options={nationalityOptions}
+                      placeholder="Selecione uma naturalidade"
+                      required
+                      value={draft.nationality}
+                    />
+                  </div>
+
+                  <div className="grid content-start gap-5">
+                    <div className="rounded-[1.5rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,250,243,0.72)] p-5">
+                      <div className="flex items-center justify-between gap-4">
+                        <div>
+                          <p className="section-eyebrow">Foto</p>
+                          <h3 className="mt-2 text-2xl font-heading text-[var(--color-green-deep)]">
+                            Identificação visual
+                          </h3>
+                        </div>
+                      </div>
+
+                      <label className="form-field mt-5">
+                        <span>Arquivo de imagem</span>
+                        <input
+                          accept=".jpg,.jpeg,.png,.webp,image/jpeg,image/png,image/webp"
+                          name="photoFile"
+                          onChange={handlePhotoChange}
+                          type="file"
+                        />
+                      </label>
+
+                      {photoState.error ? (
+                        <p className="mt-4 text-sm leading-7 text-[var(--color-red-deep)]">
+                          {photoState.error}
+                        </p>
+                      ) : null}
+
+                      <p className="mt-4 text-sm leading-7 text-[var(--color-muted)]">
+                        Envie uma foto nítida, em JPG, PNG ou WEBP, com até 5 MB.
+                        O preview ajuda na conferência visual e, ao salvar a ficha,
+                        a imagem passa a ficar persistida no cadastro do associado.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-[1.6rem] border border-[rgba(23,54,45,0.1)] bg-white/70 p-6">
+                <p className="section-eyebrow">Endereço</p>
+                <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                  <TextField
+                    label="CEP"
+                    name="cep"
+                    inputMode="numeric"
+                    maxLength={9}
+                    onBlur={handleCepLookup}
+                    onChange={handleCepChange}
+                    required
+                    value={draft.cep}
+                  />
+                  <TextField
+                    label="Rua"
+                    name="addressStreet"
+                    onChange={(value) => updateDraft("addressStreet", value)}
+                    required
+                    value={draft.addressStreet}
+                  />
+                  <TextField
+                    label="Número"
+                    name="addressNumber"
+                    onChange={(value) => updateDraft("addressNumber", value)}
+                    required
+                    value={draft.addressNumber}
+                  />
+                  <TextField
+                    label="Complemento"
+                    name="addressComplement"
+                    onChange={(value) => updateDraft("addressComplement", value)}
+                    required
+                    value={draft.addressComplement}
+                  />
+                  <TextField
+                    label="Bairro"
+                    name="addressNeighborhood"
+                    onChange={(value) => updateDraft("addressNeighborhood", value)}
+                    required
+                    value={draft.addressNeighborhood}
+                  />
+                  <TextField
+                    label="Cidade"
+                    name="addressCity"
+                    onChange={(value) => updateDraft("addressCity", value)}
+                    required
+                    value={draft.addressCity}
+                  />
+                  <TextField
+                    label="UF"
+                    maxLength={2}
+                    name="addressState"
+                    onChange={(value) =>
+                      updateDraft("addressState", value.toUpperCase())
+                    }
+                    required
+                    value={draft.addressState}
+                  />
+                </div>
+                {cepLookupState.status !== "idle" ? (
+                  <p
+                    className={`mt-4 text-sm leading-7 ${
+                      cepLookupState.status === "error"
+                        ? "text-[var(--color-red-deep)]"
+                        : cepLookupState.status === "success"
+                          ? "text-[var(--color-green-deep)]"
+                          : "text-[var(--color-muted)]"
+                    }`}
+                  >
+                    {cepLookupState.message}
+                  </p>
+                ) : (
+                  <p className="mt-4 text-sm leading-7 text-[var(--color-muted)]">
+                    Ao preencher o CEP e sair do campo, a rua, o bairro, a cidade e
+                    a UF serão sugeridos automaticamente.
+                  </p>
+                )}
+              </div>
+
+              <div className="rounded-[1.6rem] border border-[rgba(23,54,45,0.1)] bg-white/70 p-6">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="section-eyebrow">Dependentes</p>
+                    <h3 className="mt-2 text-2xl font-heading text-[var(--color-green-deep)]">
+                      Gerencie dependentes vinculados
+                    </h3>
+                  </div>
+                  <button
+                    className="secondary-button"
+                    onClick={addDependent}
+                    type="button"
+                  >
+                    + Adicionar dependente
+                  </button>
+                </div>
+
+                <div className="mt-6 grid gap-4">
+                  <button
+                    className="group flex min-h-36 w-full flex-col items-center justify-center rounded-[1.5rem] border border-dashed border-[rgba(23,54,45,0.18)] bg-[rgba(255,250,243,0.72)] p-6 text-center transition hover:border-[rgba(23,54,45,0.3)] hover:bg-[rgba(255,250,243,0.92)]"
+                    onClick={addDependent}
+                    type="button"
+                  >
+                    <span className="flex h-14 w-14 items-center justify-center rounded-full border border-[rgba(23,54,45,0.14)] bg-white text-3xl font-light text-[var(--color-green-deep)] transition group-hover:scale-105">
+                      +
+                    </span>
+                    <span className="mt-4 text-base font-semibold text-[var(--color-green-deep)]">
+                      Adicionar dependente
+                    </span>
+                    <span className="mt-2 max-w-md text-sm leading-7 text-[var(--color-muted)]">
+                      Use esta área sempre que precisar incluir o primeiro dependente
+                      ou acrescentar novos vínculos na ficha do associado.
+                    </span>
+                  </button>
+
+                  {draft.dependents.length ? (
+                    draft.dependents.map((dependent, index) => (
+                      <div
+                        className="rounded-[1.5rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,250,243,0.78)] p-5"
+                        key={dependent.id}
+                      >
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                          <p className="text-base font-semibold text-[var(--color-green-deep)]">
+                            Dependente {index + 1}
+                          </p>
+                          <button
+                            className="rounded-full border border-[rgba(154,31,43,0.2)] bg-[rgba(154,31,43,0.08)] px-5 py-2 text-sm font-semibold text-[var(--color-red-deep)] transition hover:bg-[rgba(154,31,43,0.14)]"
+                            onClick={() => removeDependent(dependent.id)}
+                            type="button"
+                          >
+                            Remover
+                          </button>
+                        </div>
+
+                        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                          <TextField
+                            label="Nome completo"
+                            onChange={(value) =>
+                              handleDependentChange(dependent.id, "fullName", value)
+                            }
+                            required
+                            value={dependent.fullName}
+                          />
+                          <SelectField
+                            label="Categoria"
+                            onChange={(value) =>
+                              handleDependentChange(
+                                dependent.id,
+                                "category",
+                                value as AssociateCategory | "",
+                              )
+                            }
+                            options={associateCategoryOptions}
+                            placeholder="Selecione uma categoria"
+                            required
+                            value={dependent.category}
+                          />
+                          <TextField
+                            label="CPF"
+                            inputMode="numeric"
+                            maxLength={14}
+                            onChange={(value) =>
+                              handleDependentChange(
+                                dependent.id,
+                                "cpf",
+                                formatCpf(value),
+                              )
+                            }
+                            required
+                            value={dependent.cpf}
+                          />
+                          <TextField
+                            label="RG"
+                            onChange={(value) =>
+                              handleDependentChange(dependent.id, "rg", value)
+                            }
+                            required
+                            value={dependent.rg}
+                          />
+                          <DateField
+                            label="Data de nascimento"
+                            onChange={(value) =>
+                              handleDependentChange(dependent.id, "birthDate", value)
+                            }
+                            required
+                            value={dependent.birthDate}
+                          />
+                          <SelectField
+                            label="Naturalidade"
+                            onChange={(value) =>
+                              handleDependentChange(
+                                dependent.id,
+                                "nationality",
+                                value as Nationality | "",
+                              )
+                            }
+                            options={nationalityOptions}
+                            placeholder="Selecione uma naturalidade"
+                            required
+                            value={dependent.nationality}
+                          />
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="rounded-[1.5rem] border border-dashed border-[rgba(23,54,45,0.14)] bg-[rgba(255,250,243,0.66)] p-5 text-sm leading-7 text-[var(--color-muted)]">
+                      Nenhum dependente cadastrado por enquanto. Quando houver necessidade,
+                      use a caixa com o símbolo de + para iniciar essa lista.
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="rounded-[1.6rem] border border-[rgba(23,54,45,0.1)] bg-white/70 p-6">
+                <label className="form-field">
+                  <span>Observação</span>
+                  <textarea
+                    className="min-h-28"
+                    name="observation"
+                    onChange={(event) => updateDraft("observation", event.target.value)}
+                    required
+                    value={draft.observation}
+                  />
+                </label>
+              </div>
+              <div className="rounded-[1.6rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,250,243,0.72)] p-6">
+                <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.75fr)] xl:items-start">
+                  <div>
+                    <p className="section-eyebrow">Termo de responsabilidade</p>
+                    <h3 className="mt-3 text-3xl font-heading text-[var(--color-green-deep)]">
+                      Aceite do associado
+                    </h3>
+                    <div className="mt-6 rounded-[1.5rem] border border-[rgba(23,54,45,0.1)] bg-white/80 p-5">
+                      <p className="whitespace-pre-line text-sm leading-7 text-[var(--color-green-deep)]">
+                        {TERM_TEXT}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-5 rounded-[1.5rem] border border-[rgba(23,54,45,0.1)] bg-white/80 p-5">
+                    <label className="flex items-start gap-3">
+                      <input
+                        checked={draft.termAccepted}
+                        name="termAccepted"
+                        onChange={(event) => updateDraft("termAccepted", event.target.checked)}
+                        type="checkbox"
+                      />
+                      <span className="text-sm leading-7 text-[var(--color-green-deep)]">
+                        Declaro ter lido e estar de pleno acordo com o termo acima
+                        descrito.
+                      </span>
+                    </label>
+
+                    <div className="grid gap-3">
+                      {saveState.error ? (
+                        <p className="text-sm font-medium text-[var(--color-red-deep)]">
+                          {saveState.error}
+                        </p>
+                      ) : null}
+                      {saveState.success ? (
+                        <p className="text-sm font-medium text-[var(--color-green-deep)]">
+                          {saveState.success}
+                        </p>
+                      ) : null}
+
+                      <div className="flex flex-col gap-3">
+                        <button
+                          className="primary-button"
+                          disabled={isSavingProfile || !draft.termAccepted}
+                          type="submit"
+                        >
+                          {isSavingProfile ? "Salvando..." : "Salvar dados do associado"}
+                        </button>
+                        <button
+                          className="secondary-button"
+                          onClick={() => {
+                            if (photoObjectUrl) {
+                              URL.revokeObjectURL(photoObjectUrl);
+                            }
+                            const restoredDraft = createDraft(profile);
+                            setDraft(restoredDraft);
+                            setLastResolvedCep(normalizeCep(restoredDraft.cep));
+                            setCepLookupState({ status: "idle" });
+                            setPhotoObjectUrl(null);
+                            setPassword("");
+                            setPasswordConfirmation("");
+                            setPasswordState({});
+                          }}
+                          type="button"
+                        >
+                          Restaurar dados carregados
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </article>
+        </form>
+
+        <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.85fr)]">
+          <article className="soft-card rounded-[2rem] p-8">
+            <p className="section-eyebrow">Segurança da Conta</p>
+            <h2 className="mt-4 text-3xl font-heading text-[var(--color-green-deep)]">
+              Senha e método de acesso
+            </h2>
+            <p className="mt-4 max-w-2xl text-sm leading-7 text-[var(--color-muted)]">
+              Este bloco fica separado da ficha para evitar competição por espaço
+              e deixar a atualização cadastral mais fluida. Se você começou com
+              Google, definir uma senha aqui habilita também o login por email e
+              senha.
+            </p>
+
+            <div className="mt-5 flex flex-wrap gap-3">
+              {accountMethods.hasGoogle ? (
+                <span className="badge-chip">Google habilitado</span>
+              ) : null}
+              {accountMethods.hasPassword ? (
+                <span className="badge-chip">Email e senha habilitados</span>
+              ) : (
+                <span className="badge-chip">Email e senha ainda não habilitados</span>
+              )}
+              <span className="badge-chip">Status ativo</span>
+            </div>
+
+            <form className="mt-8 grid gap-5 lg:max-w-2xl lg:grid-cols-2" onSubmit={handlePasswordSave}>
+              <label className="form-field">
+                <span>Nova senha</span>
+                <input
+                  autoComplete="new-password"
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                  type="password"
+                  value={password}
+                />
+              </label>
+
+              <label className="form-field">
+                <span>Confirmar senha</span>
+                <input
+                  autoComplete="new-password"
+                  onChange={(event) => setPasswordConfirmation(event.target.value)}
+                  required
+                  type="password"
+                  value={passwordConfirmation}
+                />
+              </label>
+
+              <div className="grid gap-3 lg:col-span-2">
+                {passwordState.error ? (
+                  <p className="text-sm font-medium text-[var(--color-red-deep)]">
+                    {passwordState.error}
+                  </p>
+                ) : null}
+                {passwordState.success ? (
+                  <p className="text-sm font-medium text-[var(--color-green-deep)]">
+                    {passwordState.success}
+                  </p>
+                ) : null}
+
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <button
+                    className="primary-button"
+                    disabled={isSavingPassword}
+                    type="submit"
+                  >
+                    {isSavingPassword ? "Salvando..." : "Atualizar senha"}
+                  </button>
+                </div>
+              </div>
+            </form>
+          </article>
+
+          <article className="soft-card rounded-[2rem] p-8">
+            <p className="section-eyebrow">Informações complementares</p>
+            <h2 className="mt-4 text-3xl font-heading text-[var(--color-green-deep)]">
+              Espaço reservado para próximos módulos
+            </h2>
+            <p className="mt-4 text-sm leading-7 text-[var(--color-muted)]">
+              Aqui vamos encaixar observações da associação, conteúdos
+              exclusivos e detalhes adicionais do cadastro conforme as próximas
+              issues forem amadurecendo.
+            </p>
+          </article>
+        </section>
+      </section>
+    </div>
+  );
+}
+
+function CardDataBox({
+  label,
+  value,
+  wide,
+}: {
+  label: string;
+  value: string;
+  wide?: boolean;
+}) {
+  return (
+    <div
+      className={`border-b border-[rgba(23,59,47,0.16)] px-0 pb-3 pt-3 ${
+        wide ? "sm:col-span-2 xl:col-span-2" : ""
+      }`}
+    >
+      <p className="text-[0.64rem] font-black uppercase tracking-[0.22em] text-[var(--color-muted)]">
+        {label}
+      </p>
+      <p className="mt-2 text-[0.98rem] font-extrabold leading-6 text-[var(--color-green-deep)]">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function AssociateMiniCard({
+  birthDate,
+  category,
+  cpf,
+  fullName,
+  nationality,
+  photoUrl,
+  profileId,
+}: {
+  birthDate: string;
+  category: string;
+  cpf: string;
+  fullName: string;
+  nationality: string;
+  photoUrl: string | null;
+  profileId: string;
+}) {
+  async function handleDownloadCard() {
+    const canvas = document.createElement("canvas");
+    const width = 760;
+    const height = 480;
+    canvas.width = width;
+    canvas.height = height;
+
+    const context = canvas.getContext("2d");
+
+    if (!context) {
+      return;
+    }
+
+    context.fillStyle = "#efe1c9";
+    context.fillRect(0, 0, width, height);
+
+    drawRoundedRect(context, 14, 14, width - 28, height - 28, 34);
+
+    const gradient = context.createLinearGradient(0, 0, width, height);
+    gradient.addColorStop(0, "#fffaf2");
+    gradient.addColorStop(1, "#f8efe1");
+    context.fillStyle = gradient;
+    context.fill();
+
+    context.save();
+    drawRoundedRect(context, 14, 14, width - 28, height - 28, 34);
+    context.clip();
+    context.fillStyle = "#173b2f";
+    context.fillRect(14, 14, 258, height - 28);
+    context.restore();
+
+    context.strokeStyle = "rgba(23,59,47,0.12)";
+    context.lineWidth = 1;
+    drawRoundedRect(context, 24, 24, width - 48, height - 48, 26);
+    context.stroke();
+
+    context.fillStyle = "rgba(255,247,237,0.96)";
+    context.beginPath();
+    context.arc(83, 90, 34, 0, Math.PI * 2);
+    context.fill();
+
+    context.fillStyle = "#173b2f";
+    context.font = '700 30px "Cormorant Garamond", Georgia, serif';
+    context.textAlign = "center";
+    context.fillText("AAJF", 83, 99);
+
+    context.textAlign = "left";
+    context.fillStyle = "rgba(255,247,237,0.84)";
+    context.font = '700 12px "Geist", system-ui, sans-serif';
+    drawMultilineText(
+      context,
+      "ASSOCIAÇÃO CULTURAL E RECREATIVA BRASIL-ALEMANHA",
+      48,
+      156,
+      165,
+      18,
+    );
+
+    drawMiniQr(context, 48, 330, 84);
+    context.fillStyle = "rgba(255,247,237,0.74)";
+    context.font = '500 11px "Geist", system-ui, sans-serif';
+    drawMultilineText(
+      context,
+      "Documento digital de identificação do associado.",
+      48,
+      430,
+      160,
+      16,
+    );
+
+    context.fillStyle = "#d8b45f";
+    context.font = '800 12px "Geist", system-ui, sans-serif';
+    context.fillText("CARTEIRA DO ASSOCIADO", 316, 72);
+
+    context.fillStyle = "#5f7268";
+    context.font = '800 12px "Geist", system-ui, sans-serif';
+    context.fillText("ASSOCIADO", 316, 114);
+
+    context.textAlign = "right";
+    context.fillText(formatAssociateCardId(profileId), 704, 72);
+    context.textAlign = "left";
+
+    context.fillStyle = "#173b2f";
+    context.font = '400 68px "Cormorant Garamond", Georgia, serif';
+    drawMultilineText(context, fullName, 316, 182, 290, 66);
+
+    await drawPhotoBlock(context, photoUrl, 610, 92, 130, 160);
+
+    drawCardField(context, "Categoria", category, 316, 288, 150);
+    drawCardField(context, "CPF", cpf, 478, 288, 126);
+    drawCardField(context, "Nascimento", birthDate, 622, 288, 82);
+    drawCardField(context, "Naturalidade", nationality, 316, 370, 288);
+    drawCardField(context, "Validade", "31/12/2026", 622, 370, 82);
+
+    context.strokeStyle = "rgba(23,59,47,0.22)";
+    context.setLineDash([4, 5]);
+    context.beginPath();
+    context.moveTo(316, 408);
+    context.lineTo(704, 408);
+    context.stroke();
+    context.setLineDash([]);
+
+    drawStatusPill(context, 316, 430, "Associado ativo");
+
+    context.fillStyle = "#5f7268";
+    context.font = '500 11px "Geist", system-ui, sans-serif';
+    context.textAlign = "right";
+    drawMultilineText(
+      context,
+      "Uso interno da Associação Alemã de Juiz de Fora. Validação mediante QR Code.",
+      704,
+      438,
+      180,
+      16,
+      "right",
+    );
+
+    const downloadLink = document.createElement("a");
+    downloadLink.href = canvas.toDataURL("image/png");
+    downloadLink.download = `${slugifyFileName(fullName || "associado")}-carteirinha.png`;
+    downloadLink.click();
+  }
+
+  return (
+    <button
+      className="group block w-[18rem] cursor-pointer rounded-[1rem] bg-transparent text-left transition-transform hover:-translate-y-1"
+      onClick={handleDownloadCard}
+      title="Clique para baixar a carteirinha em PNG"
+      type="button"
+    >
+      <article className="relative w-[18rem] overflow-hidden rounded-[1rem] border border-white/85 bg-[linear-gradient(135deg,#fffaf2,var(--color-paper))] shadow-[0_14px_32px_rgba(16,46,37,0.14)]">
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(115deg,rgba(255,255,255,0.42),transparent_30%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,var(--color-green-deep)_0_34%,transparent_34%),radial-gradient(circle_at_88%_90%,rgba(185,28,28,0.12),transparent_30%),radial-gradient(circle_at_55%_0%,rgba(216,180,95,0.14),transparent_34%)]" />
+      <div className="pointer-events-none absolute inset-[4px] rounded-[0.8rem] border border-[rgba(23,59,47,0.12)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(118deg,transparent_0_38%,rgba(255,255,255,0.32)_47%,transparent_58%)] opacity-50" />
+
+      <div className="relative z-[1] grid aspect-[1.586/1] grid-cols-[4.2rem_minmax(0,1fr)]">
+        <aside className="flex flex-col justify-between px-2.5 py-2.5 text-[var(--color-paper)]">
+          <div>
+            <div className="grid h-6 w-6 place-items-center rounded-full bg-[rgba(255,247,237,0.96)] text-[0.48rem] font-bold text-[var(--color-green-deep)]">
+              <span className="font-heading">AAJF</span>
+            </div>
+            <p className="mt-2 text-[0.28rem] uppercase tracking-[0.14em] text-[rgba(255,247,237,0.82)]">
+              Associação Cultural e Recreativa Brasil-Alemanha
+            </p>
+          </div>
+
+          <div>
+            <div className="grid h-5 w-5 place-items-center rounded-[0.35rem] border-[3px] border-[var(--color-paper)] bg-[linear-gradient(90deg,var(--color-green-deep)_3px,transparent_3px)_0_0/6px_6px,linear-gradient(var(--color-green-deep)_3px,transparent_3px)_0_0/6px_6px,#fff7ed]" />
+            <p className="mt-2 text-[0.28rem] leading-[1.25] text-[rgba(255,247,237,0.74)]">
+              Documento digital do associado.
+            </p>
+          </div>
+        </aside>
+
+        <section className="flex flex-col justify-between px-2.5 py-2.5">
+          <div>
+            <header className="flex items-start justify-between gap-2">
+              <p className="text-[0.28rem] font-extrabold uppercase tracking-[0.18em] text-[var(--color-gold-strong)]">
+                Carteira do Associado
+              </p>
+              <span className="whitespace-nowrap text-[0.3rem] font-extrabold tracking-[0.08em] text-[var(--color-muted)]">
+                {formatAssociateCardId(profileId)}
+              </span>
+            </header>
+
+            <div className="mt-1.5 flex items-start justify-between gap-2">
+              <div>
+                <p className="mb-1 text-[0.3rem] font-extrabold uppercase tracking-[0.14em] text-[var(--color-muted)]">
+                  Associado
+                </p>
+                <h3 className="max-w-[6.5rem] font-heading text-[1.08rem] leading-[0.92] tracking-[-0.04em] text-[var(--color-green-deep)]">
+                  {fullName}
+                </h3>
+              </div>
+
+              <div className="grid h-11 w-9 flex-none place-items-center overflow-hidden rounded-[0.6rem] border border-[rgba(23,59,47,0.18)] bg-[linear-gradient(135deg,#e8dfd1,#fffaf2)] shadow-[0_8px_18px_rgba(23,59,47,0.1),inset_0_0_0_2px_rgba(255,255,255,0.7)]">
+                {photoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    alt={`Foto de ${fullName}`}
+                    className="h-full w-full object-cover"
+                    src={photoUrl}
+                  />
+                ) : (
+                  <div className="px-1 text-center text-[0.24rem] font-black uppercase tracking-[0.08em] text-[var(--color-muted)]">
+                    Sem foto
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <section className="mt-2.5 grid grid-cols-2 gap-x-2 gap-y-1.5">
+              <MiniCardDataBox label="Categoria" value={category} />
+              <MiniCardDataBox label="CPF" value={cpf} />
+              <MiniCardDataBox label="Nascimento" value={birthDate} />
+              <MiniCardDataBox label="Naturalidade" value={nationality} />
+            </section>
+          </div>
+
+          <footer className="mt-2 flex items-end justify-between gap-2 border-t border-dashed border-[rgba(23,59,47,0.16)] pt-1.5">
+            <div className="inline-flex items-center gap-1 rounded-full border border-[rgba(23,59,47,0.12)] bg-[rgba(23,59,47,0.08)] px-1.5 py-0.5 text-[0.28rem] font-black text-[var(--color-green-deep)]">
+              <span className="h-1 w-1 rounded-full bg-[#22c55e] shadow-[0_0_8px_rgba(34,197,94,0.85)]" />
+              Ativo
+            </div>
+            <p className="max-w-[4.25rem] text-right text-[0.24rem] leading-[1.2] text-[var(--color-muted)]">
+              Uso interno da AAJF.
+            </p>
+          </footer>
+        </section>
+      </div>
+      </article>
+    </button>
+  );
+}
+
+function MiniCardDataBox({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-b border-[rgba(23,59,47,0.12)] pb-1">
+      <p className="text-[0.22rem] font-black uppercase tracking-[0.12em] text-[var(--color-muted)]">
+        {label}
+      </p>
+      <p className="mt-0.5 text-[0.34rem] font-extrabold leading-[1.25] text-[var(--color-green-deep)]">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+async function drawPhotoBlock(
+  context: CanvasRenderingContext2D,
+  photoUrl: string | null,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) {
+  drawRoundedRect(context, x, y, width, height, 22);
+  const gradient = context.createLinearGradient(x, y, x + width, y + height);
+  gradient.addColorStop(0, "#e8dfd1");
+  gradient.addColorStop(1, "#fffaf2");
+  context.fillStyle = gradient;
+  context.fill();
+
+  context.save();
+  drawRoundedRect(context, x, y, width, height, 22);
+  context.clip();
+
+  if (photoUrl) {
+    try {
+      const image = await loadImage(photoUrl);
+      context.drawImage(image, x, y, width, height);
+    } catch {
+      // Fallback to placeholder text below.
+    }
+  }
+
+  context.restore();
+
+  context.strokeStyle = "rgba(23,59,47,0.18)";
+  context.lineWidth = 1;
+  drawRoundedRect(context, x, y, width, height, 22);
+  context.stroke();
+
+  context.strokeStyle = "rgba(255,255,255,0.72)";
+  context.lineWidth = 6;
+  drawRoundedRect(context, x + 6, y + 6, width - 12, height - 12, 18);
+  context.stroke();
+
+  if (!photoUrl) {
+    context.fillStyle = "#5f7268";
+    context.font = '900 18px "Geist", system-ui, sans-serif';
+    context.textAlign = "center";
+    drawMultilineText(context, "SEM\nFOTO", x + width / 2, y + 78, width - 26, 22, "center");
+    context.textAlign = "left";
+  }
+}
+
+function drawCardField(
+  context: CanvasRenderingContext2D,
+  label: string,
+  value: string,
+  x: number,
+  y: number,
+  width: number,
+) {
+  context.fillStyle = "#5f7268";
+  context.font = '900 12px "Geist", system-ui, sans-serif';
+  context.fillText(label.toUpperCase(), x, y);
+
+  context.fillStyle = "#173b2f";
+  context.font = '800 19px "Geist", system-ui, sans-serif';
+  context.fillText(value, x, y + 28);
+
+  context.strokeStyle = "rgba(23,59,47,0.16)";
+  context.lineWidth = 1;
+  context.beginPath();
+  context.moveTo(x, y + 44);
+  context.lineTo(x + width, y + 44);
+  context.stroke();
+}
+
+function drawStatusPill(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  label: string,
+) {
+  drawRoundedRect(context, x, y, 112, 34, 17);
+  context.fillStyle = "rgba(23,59,47,0.08)";
+  context.fill();
+  context.strokeStyle = "rgba(23,59,47,0.12)";
+  context.lineWidth = 1;
+  context.stroke();
+
+  context.fillStyle = "#22c55e";
+  context.beginPath();
+  context.arc(x + 20, y + 17, 5, 0, Math.PI * 2);
+  context.fill();
+
+  context.fillStyle = "#173b2f";
+  context.font = '900 12px "Geist", system-ui, sans-serif';
+  context.fillText(label, x + 34, y + 21);
+}
+
+function drawMiniQr(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+) {
+  drawRoundedRect(context, x, y, size, size, 18);
+  context.fillStyle = "#fff7ed";
+  context.fill();
+
+  context.lineWidth = 8;
+  context.strokeStyle = "#fff7ed";
+  context.stroke();
+
+  const cell = 12;
+  context.fillStyle = "#173b2f";
+  const pattern = [
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 1, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+  ];
+
+  for (let row = 0; row < pattern.length; row += 1) {
+    for (let col = 0; col < pattern[row].length; col += 1) {
+      if (!pattern[row][col]) continue;
+      context.fillRect(x + 10 + col * cell, y + 10 + row * cell, 8, 8);
+    }
+  }
+}
+
+function drawRoundedRect(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+) {
+  context.beginPath();
+  context.moveTo(x + radius, y);
+  context.lineTo(x + width - radius, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + radius);
+  context.lineTo(x + width, y + height - radius);
+  context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+  context.lineTo(x + radius, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - radius);
+  context.lineTo(x, y + radius);
+  context.quadraticCurveTo(x, y, x + radius, y);
+  context.closePath();
+}
+
+function drawMultilineText(
+  context: CanvasRenderingContext2D,
+  value: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  lineHeight: number,
+  align: CanvasTextAlign = "left",
+) {
+  const words = value.split(/\s+/);
+  const lines: string[] = [];
+  let currentLine = "";
+
+  for (const word of words) {
+    if (word.includes("\n")) {
+      const parts = word.split("\n");
+
+      for (let index = 0; index < parts.length; index += 1) {
+        const part = parts[index];
+        const candidate = currentLine ? `${currentLine} ${part}`.trim() : part;
+
+        if (context.measureText(candidate).width > maxWidth && currentLine) {
+          lines.push(currentLine);
+          currentLine = part;
+        } else {
+          currentLine = candidate;
+        }
+
+        if (index < parts.length - 1) {
+          lines.push(currentLine);
+          currentLine = "";
+        }
+      }
+
+      continue;
+    }
+
+    const candidate = currentLine ? `${currentLine} ${word}` : word;
+
+    if (context.measureText(candidate).width > maxWidth && currentLine) {
+      lines.push(currentLine);
+      currentLine = word;
+    } else {
+      currentLine = candidate;
+    }
+  }
+
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+
+  context.textAlign = align;
+
+  lines.forEach((line, index) => {
+    context.fillText(line, x, y + index * lineHeight);
+  });
+
+  context.textAlign = "left";
+}
+
+function loadImage(src: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = src;
+  });
+}
+
+function slugifyFileName(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+function TextField({
+  label,
+  inputMode,
+  maxLength,
+  name,
+  onBlur,
+  onChange,
+  required,
+  value,
+}: {
+  label: string;
+  inputMode?: React.HTMLAttributes<HTMLInputElement>["inputMode"];
+  maxLength?: number;
+  name?: string;
+  onBlur?: () => void;
+  onChange: (value: string) => void;
+  required?: boolean;
+  value: string;
+}) {
+  return (
+    <label className="form-field">
+      <span>{label}</span>
+      <input
+        inputMode={inputMode}
+        maxLength={maxLength}
+        name={name}
+        onBlur={onBlur}
+        onChange={(event) => onChange(event.target.value)}
+        required={required}
+        value={value}
+      />
+    </label>
+  );
+}
+
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <label className="form-field">
+      <span>{label}</span>
+      <input readOnly value={value} />
+    </label>
+  );
+}
+
+function DateField({
+  label,
+  name,
+  onChange,
+  required,
+  value,
+}: {
+  label: string;
+  name?: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+  value: string;
+}) {
+  return (
+    <label className="form-field">
+      <span>{label}</span>
+      <input
+        name={name}
+        onChange={(event) => onChange(event.target.value)}
+        required={required}
+        type="date"
+        value={value}
+      />
+    </label>
+  );
+}
+
+function SelectField({
+  label,
+  name,
+  onChange,
+  options,
+  placeholder,
+  required,
+  value,
+}: {
+  label: string;
+  name?: string;
+  onChange: (value: string) => void;
+  options: readonly string[];
+  placeholder: string;
+  required?: boolean;
+  value: string;
+}) {
+  return (
+    <label className="form-field">
+      <span>{label}</span>
+      <select
+        className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-[rgba(255,250,243,0.88)] px-4 py-3 text-[var(--color-ink)]"
+        name={name}
+        onChange={(event) => onChange(event.target.value)}
+        required={required}
+        value={value}
+      >
+        <option value="">{placeholder}</option>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function createDraft(profile: AssociateProfileRecord): AssociateDraft {
+  return {
+    addressCity: profile.addressCity,
+    addressComplement: profile.addressComplement,
+    addressNeighborhood: profile.addressNeighborhood,
+    addressNumber: profile.addressNumber,
+    addressState: profile.addressState,
+    addressStreet: profile.addressStreet,
+    birthDate: profile.birthDate,
+    category: profile.category ?? "",
+    cep: profile.cep,
+    cpf: profile.cpf,
+    dependents: profile.dependents.map((dependent) => ({
+      birthDate: dependent.birthDate,
+      category: dependent.category ?? "",
+      cpf: dependent.cpf ?? "",
+      fullName: dependent.fullName,
+      id: dependent.id,
+      nationality: dependent.nationality ?? "",
+      rg: dependent.rg ?? "",
+    })),
+    email: profile.email,
+    fullName: profile.fullName,
+    nationality: profile.nationality ?? "",
+    observation: profile.observation,
+    phone: profile.phone,
+    photoUrl: profile.photoUrl,
+    rg: profile.rg,
+    termAccepted: profile.termAccepted,
+  };
+}
+
+function createClientId() {
+  if (typeof globalThis !== "undefined" && globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+
+  return `dependent-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function formatDate(value: string) {
+  if (!value) {
+    return "Não informado";
+  }
+
+  const [year, month, day] = value.split("-");
+
+  if (!year || !month || !day) {
+    return value;
+  }
+
+  return `${day}/${month}/${year}`;
+}
+
+function formatAssociateCardId(profileId: string) {
+  const suffix = profileId.replace(/-/g, "").slice(-6).toUpperCase();
+  return `AAJF-${suffix || "TEMP"}`;
+}
+
+function formatCpf(value: string) {
+  const digits = value.replace(/\D/g, "").slice(0, 11);
+
+  if (digits.length <= 3) {
+    return digits;
+  }
+
+  if (digits.length <= 6) {
+    return `${digits.slice(0, 3)}.${digits.slice(3)}`;
+  }
+
+  if (digits.length <= 9) {
+    return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6)}`;
+  }
+
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+}
+
+function formatPhone(value: string) {
+  const digits = value.replace(/\D/g, "").slice(0, 11);
+
+  if (digits.length <= 2) {
+    return digits.length ? `(${digits}` : "";
+  }
+
+  if (digits.length <= 6) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2)}`;
+  }
+
+  if (digits.length <= 10) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  }
+
+  return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+}
+
+type ViaCepResponse = {
+  bairro?: string;
+  erro?: boolean;
+  localidade?: string;
+  logradouro?: string;
+  uf?: string;
+};
+
+function formatCep(value: string) {
+  const digits = normalizeCep(value).slice(0, 8);
+
+  if (digits.length <= 5) {
+    return digits;
+  }
+
+  return `${digits.slice(0, 5)}-${digits.slice(5)}`;
+}
+
+function normalizeCep(value: string) {
+  return value.replace(/\D/g, "");
+}
+
+function isValidCep(value: string) {
+  return /^\d{8}$/.test(value);
+}

--- a/src/components/associate-area-manager.tsx
+++ b/src/components/associate-area-manager.tsx
@@ -199,7 +199,9 @@ export function AssociateAreaManager({
       return;
     }
 
-    if (!associatePhotoAcceptedMimeTypes.includes(file.type)) {
+    if (
+      !(associatePhotoAcceptedMimeTypes as readonly string[]).includes(file.type)
+    ) {
       setPhotoState({
         error: "Use uma imagem JPG, PNG ou WEBP para a foto do associado.",
       });

--- a/src/lib/supabase/admin-associates.ts
+++ b/src/lib/supabase/admin-associates.ts
@@ -1,0 +1,133 @@
+import { getAdminAccess, type AdminAccess } from "@/lib/supabase/access";
+import type { AssociateCategory } from "@/lib/supabase/associate-profile-shared";
+import { createClient } from "@/lib/supabase/server";
+
+export type AdminAssociateMembershipRecord = {
+  grantedAt: string;
+  id: string;
+  notes: string | null;
+  profile: {
+    email: string;
+    fullName: string | null;
+    id: string;
+  };
+  profileSnapshot: {
+    category: AssociateCategory | null;
+    phone: string | null;
+  } | null;
+  status: "active" | "inactive" | "suspended";
+};
+
+export type AssociateBootstrapGrantRecord = {
+  claimedAt: string | null;
+  email: string;
+  id: string;
+  membershipStatus: "active" | "inactive" | "suspended";
+  notes: string | null;
+  status: "pending" | "claimed" | "revoked";
+};
+
+export type AdminAssociatesData =
+  | { access: Extract<AdminAccess, { status: "unconfigured" | "unauthenticated" | "denied" }> }
+  | {
+      access: Extract<AdminAccess, { status: "authorized" }>;
+      bootstrapGrants: AssociateBootstrapGrantRecord[];
+      memberships: AdminAssociateMembershipRecord[];
+    };
+
+export async function getAdminAssociatesData(): Promise<AdminAssociatesData> {
+  const access = await getAdminAccess();
+
+  if (access.status !== "authorized") {
+    return { access };
+  }
+
+  const supabase = await createClient();
+  const [
+    { data: membershipsData, error: membershipsError },
+    { data: grantsData, error: grantsError },
+    { data: associateProfilesData, error: associateProfilesError },
+  ] =
+    await Promise.all([
+      supabase
+        .schema("aajf")
+        .from("associate_memberships")
+        .select(
+          "id, status, granted_at, notes, profile_id, profile:profiles!associate_memberships_profile_id_fkey(id, email, full_name)",
+        )
+        .order("granted_at", { ascending: false }),
+      supabase
+        .schema("aajf")
+        .from("associate_bootstrap_grants")
+        .select("id, email, status, membership_status, claimed_at, notes")
+        .order("created_at", { ascending: false }),
+      supabase
+        .schema("aajf")
+        .from("associate_profiles")
+        .select("profile_id, category, phone"),
+    ]);
+
+  if (membershipsError) {
+    throw membershipsError;
+  }
+
+  if (grantsError) {
+    throw grantsError;
+  }
+
+  if (associateProfilesError) {
+    throw associateProfilesError;
+  }
+
+  const associateProfilesByProfileId = new Map(
+    (associateProfilesData ?? []).map((profile) => [profile.profile_id, profile]),
+  );
+
+  const memberships: AdminAssociateMembershipRecord[] = (membershipsData ?? [])
+    .map((membership) => {
+      const profile = Array.isArray(membership.profile)
+        ? membership.profile[0]
+        : membership.profile;
+      const associateProfile = associateProfilesByProfileId.get(membership.profile_id);
+
+      if (!profile) {
+        return null;
+      }
+
+      return {
+        grantedAt: membership.granted_at,
+        id: membership.id,
+        notes: membership.notes,
+        profile: {
+          email: profile.email,
+          fullName: profile.full_name,
+          id: profile.id,
+        },
+        profileSnapshot: associateProfile
+          ? {
+              category: associateProfile.category,
+              phone: associateProfile.phone,
+            }
+          : null,
+        status: membership.status,
+      } as AdminAssociateMembershipRecord;
+    })
+    .filter((membership): membership is AdminAssociateMembershipRecord => membership !== null);
+
+  const bootstrapGrants: AssociateBootstrapGrantRecord[] = (grantsData ?? []).map(
+    (grant) => ({
+      claimedAt: grant.claimed_at,
+      email: grant.email,
+      id: grant.id,
+      membershipStatus: grant.membership_status,
+      notes: grant.notes,
+      status: grant.status,
+    }),
+  );
+
+  return {
+    access,
+    bootstrapGrants,
+    memberships,
+  };
+}

--- a/src/lib/supabase/associate-profile-shared.ts
+++ b/src/lib/supabase/associate-profile-shared.ts
@@ -1,0 +1,76 @@
+export const associatePhotoBucketName = "associate-profile-photos";
+export const associatePhotoAcceptedMimeTypes = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
+export const associatePhotoMaxFileSizeInBytes = 5 * 1024 * 1024;
+
+export const associateCategoryOptions = [
+  "Kleine Kinder",
+  "Gosse Kinder",
+  "Heimweh",
+] as const;
+
+export const nationalityOptions = [
+  "Brasileira",
+  "Alemã",
+  "Portuguesa",
+  "Italiana",
+  "Outra",
+] as const;
+
+export type AssociateCategory = (typeof associateCategoryOptions)[number];
+export type Nationality = (typeof nationalityOptions)[number];
+
+export type AssociateDependentRecord = {
+  birthDate: string;
+  category: AssociateCategory | null;
+  cpf: string | null;
+  fullName: string;
+  id: string;
+  nationality: Nationality | null;
+  rg: string | null;
+};
+
+export type AssociateProfileRecord = {
+  addressCity: string;
+  addressComplement: string;
+  addressNeighborhood: string;
+  addressNumber: string;
+  addressState: string;
+  addressStreet: string;
+  birthDate: string;
+  category: AssociateCategory | null;
+  cep: string;
+  cpf: string;
+  dependents: AssociateDependentRecord[];
+  email: string;
+  fullName: string;
+  nationality: Nationality | null;
+  observation: string;
+  phone: string;
+  photoUrl: string | null;
+  profileId: string;
+  rg: string;
+  termAccepted: boolean;
+};
+
+export type AssociateAuthMethods = {
+  hasGoogle: boolean;
+  hasPassword: boolean;
+};
+
+export type AssociateAccess =
+  | { status: "unconfigured" }
+  | { status: "unauthenticated" }
+  | { email?: string; membershipStatus?: "inactive" | "suspended"; status: "denied" }
+  | { email?: string; profileId: string; status: "authorized" };
+
+export type AssociateAreaData =
+  | { access: Exclude<AssociateAccess, { status: "authorized" }> }
+  | {
+      access: Extract<AssociateAccess, { status: "authorized" }>;
+      authMethods: AssociateAuthMethods;
+      profile: AssociateProfileRecord;
+    };

--- a/src/lib/supabase/associate-profile.ts
+++ b/src/lib/supabase/associate-profile.ts
@@ -6,7 +6,6 @@ import type {
   AssociateAreaData,
   AssociateAuthMethods,
   AssociateDependentRecord,
-  AssociateProfileRecord,
 } from "@/lib/supabase/associate-profile-shared";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/lib/supabase/associate-profile.ts
+++ b/src/lib/supabase/associate-profile.ts
@@ -1,0 +1,147 @@
+import "server-only";
+import { getSupabaseConfig } from "@/lib/supabase/config";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { associatePhotoBucketName } from "@/lib/supabase/associate-profile-shared";
+import type {
+  AssociateAreaData,
+  AssociateAuthMethods,
+  AssociateDependentRecord,
+  AssociateProfileRecord,
+} from "@/lib/supabase/associate-profile-shared";
+import { createClient } from "@/lib/supabase/server";
+
+export async function getAssociateAreaData(): Promise<AssociateAreaData> {
+  if (!getSupabaseConfig()) {
+    return { access: { status: "unconfigured" } };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { access: { status: "unauthenticated" } };
+  }
+
+  const providers = Array.isArray(user.app_metadata?.providers)
+    ? user.app_metadata.providers
+    : [];
+  const authMethods: AssociateAuthMethods = {
+    hasGoogle: providers.includes("google"),
+    hasPassword: providers.includes("email"),
+  };
+
+  const { data: membership, error: membershipError } = await supabase
+    .schema("aajf")
+    .from("associate_memberships")
+    .select("status")
+    .eq("profile_id", user.id)
+    .maybeSingle();
+
+  if (membershipError || !membership) {
+    return { access: { status: "denied", email: user.email } };
+  }
+
+  if (membership.status !== "active") {
+    return {
+      access: {
+        status: "denied",
+        email: user.email,
+        membershipStatus: membership.status,
+      },
+    };
+  }
+
+  const [{ data: profileData, error: profileError }, { data: associateProfileData, error: associateProfileError }] =
+    await Promise.all([
+      supabase
+        .schema("aajf")
+        .from("profiles")
+        .select("id, email, full_name")
+        .eq("id", user.id)
+        .maybeSingle(),
+      supabase
+        .schema("aajf")
+        .from("associate_profiles")
+        .select(
+          "id, photo_url, full_name, category, cpf, rg, phone, birth_date, nationality, cep, street, number, complement, neighborhood, city, state, observation, term_accepted, associate_dependents(id, full_name, category, cpf, rg, birth_date, nationality)",
+        )
+        .eq("profile_id", user.id)
+        .maybeSingle(),
+    ]);
+
+  if (profileError) {
+    throw profileError;
+  }
+
+  if (associateProfileError) {
+    throw associateProfileError;
+  }
+
+  const dependents: AssociateDependentRecord[] = (
+    associateProfileData?.associate_dependents ?? []
+  ).map((dependent) => ({
+    birthDate: dependent.birth_date ?? "",
+    category: dependent.category,
+    cpf: dependent.cpf,
+    fullName: dependent.full_name,
+    id: dependent.id,
+    nationality: dependent.nationality,
+    rg: dependent.rg,
+  }));
+
+  const photoUrl = await resolveAssociatePhotoUrl(associateProfileData?.photo_url ?? null);
+
+  return {
+    access: {
+      status: "authorized",
+      email: profileData?.email ?? user.email,
+      profileId: user.id,
+    },
+    authMethods,
+    profile: {
+      addressCity: associateProfileData?.city ?? "",
+      addressComplement: associateProfileData?.complement ?? "",
+      addressNeighborhood: associateProfileData?.neighborhood ?? "",
+      addressNumber: associateProfileData?.number ?? "",
+      addressState: associateProfileData?.state ?? "",
+      addressStreet: associateProfileData?.street ?? "",
+      birthDate: associateProfileData?.birth_date ?? "",
+      category: associateProfileData?.category ?? null,
+      cep: associateProfileData?.cep ?? "",
+      cpf: associateProfileData?.cpf ?? "",
+      dependents,
+      email: profileData?.email ?? user.email ?? "",
+      fullName: associateProfileData?.full_name ?? profileData?.full_name ?? "",
+      nationality: associateProfileData?.nationality ?? null,
+      observation: associateProfileData?.observation ?? "",
+      phone: associateProfileData?.phone ?? "",
+      photoUrl,
+      profileId: user.id,
+      rg: associateProfileData?.rg ?? "",
+      termAccepted: associateProfileData?.term_accepted ?? false,
+    },
+  };
+}
+
+async function resolveAssociatePhotoUrl(photoPath: string | null) {
+  if (!photoPath) {
+    return null;
+  }
+
+  try {
+    const adminSupabase = createAdminClient();
+    const { data, error } = await adminSupabase.storage
+      .from(associatePhotoBucketName)
+      .createSignedUrl(photoPath, 60 * 60);
+
+    if (error) {
+      return null;
+    }
+
+    return data.signedUrl;
+  } catch {
+    return null;
+  }
+}

--- a/supabase/migrations/20260503113000_associate_profiles.sql
+++ b/supabase/migrations/20260503113000_associate_profiles.sql
@@ -1,0 +1,179 @@
+-- Associate profile data for AAJF.
+-- Keeps associate-facing profile details separate from generic auth profiles
+-- and from administrative memberships.
+
+create table if not exists aajf.associate_profiles (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references aajf.profiles (id) on delete cascade,
+  photo_url text,
+  full_name text,
+  category text,
+  cpf text,
+  rg text,
+  phone text,
+  birth_date date,
+  nationality text,
+  cep text,
+  street text,
+  number text,
+  complement text,
+  neighborhood text,
+  city text,
+  state text,
+  observation text,
+  term_accepted boolean not null default false,
+  term_accepted_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint associate_profiles_profile_unique unique (profile_id),
+  constraint associate_profiles_category_check
+    check (category is null or category in ('Kleine Kinder', 'Gosse Kinder', 'Heimweh'))
+);
+
+create table if not exists aajf.associate_dependents (
+  id uuid primary key default gen_random_uuid(),
+  associate_profile_id uuid not null references aajf.associate_profiles (id) on delete cascade,
+  full_name text not null,
+  category text,
+  cpf text,
+  rg text,
+  birth_date date,
+  nationality text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint associate_dependents_category_check
+    check (category is null or category in ('Kleine Kinder', 'Gosse Kinder', 'Heimweh'))
+);
+
+create index if not exists associate_profiles_profile_idx
+  on aajf.associate_profiles (profile_id);
+
+create index if not exists associate_dependents_profile_idx
+  on aajf.associate_dependents (associate_profile_id);
+
+drop trigger if exists set_associate_profiles_updated_at on aajf.associate_profiles;
+create trigger set_associate_profiles_updated_at
+before update on aajf.associate_profiles
+for each row execute function aajf.set_updated_at();
+
+drop trigger if exists set_associate_dependents_updated_at on aajf.associate_dependents;
+create trigger set_associate_dependents_updated_at
+before update on aajf.associate_dependents
+for each row execute function aajf.set_updated_at();
+
+alter table aajf.associate_profiles enable row level security;
+alter table aajf.associate_dependents enable row level security;
+
+create policy "associate_profiles_select_own_or_admin"
+on aajf.associate_profiles
+for select
+to authenticated
+using (
+  profile_id = auth.uid()
+  or app_private.is_active_admin(auth.uid())
+);
+
+create policy "associate_profiles_insert_own_or_admin"
+on aajf.associate_profiles
+for insert
+to authenticated
+with check (
+  profile_id = auth.uid()
+  or app_private.is_active_admin(auth.uid())
+);
+
+create policy "associate_profiles_update_own_or_admin"
+on aajf.associate_profiles
+for update
+to authenticated
+using (
+  profile_id = auth.uid()
+  or app_private.is_active_admin(auth.uid())
+)
+with check (
+  profile_id = auth.uid()
+  or app_private.is_active_admin(auth.uid())
+);
+
+create policy "associate_dependents_select_own_or_admin"
+on aajf.associate_dependents
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from aajf.associate_profiles
+    where associate_profiles.id = associate_dependents.associate_profile_id
+      and (
+        associate_profiles.profile_id = auth.uid()
+        or app_private.is_active_admin(auth.uid())
+      )
+  )
+);
+
+create policy "associate_dependents_insert_own_or_admin"
+on aajf.associate_dependents
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from aajf.associate_profiles
+    where associate_profiles.id = associate_dependents.associate_profile_id
+      and (
+        associate_profiles.profile_id = auth.uid()
+        or app_private.is_active_admin(auth.uid())
+      )
+  )
+);
+
+create policy "associate_dependents_update_own_or_admin"
+on aajf.associate_dependents
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from aajf.associate_profiles
+    where associate_profiles.id = associate_dependents.associate_profile_id
+      and (
+        associate_profiles.profile_id = auth.uid()
+        or app_private.is_active_admin(auth.uid())
+      )
+  )
+)
+with check (
+  exists (
+    select 1
+    from aajf.associate_profiles
+    where associate_profiles.id = associate_dependents.associate_profile_id
+      and (
+        associate_profiles.profile_id = auth.uid()
+        or app_private.is_active_admin(auth.uid())
+      )
+  )
+);
+
+create policy "associate_dependents_delete_own_or_admin"
+on aajf.associate_dependents
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from aajf.associate_profiles
+    where associate_profiles.id = associate_dependents.associate_profile_id
+      and (
+        associate_profiles.profile_id = auth.uid()
+        or app_private.is_active_admin(auth.uid())
+      )
+  )
+);
+
+grant select, insert, update
+  on table aajf.associate_profiles
+  to authenticated;
+
+grant select, insert, update, delete
+  on table aajf.associate_dependents
+  to authenticated;

--- a/supabase/migrations/20260503133000_grant_associate_table_privileges.sql
+++ b/supabase/migrations/20260503133000_grant_associate_table_privileges.sql
@@ -1,0 +1,11 @@
+-- Grant SQL privileges required for associate membership flows.
+-- RLS policies already protect row access, but authenticated users still need
+-- table-level privileges before policies can be evaluated.
+
+grant select, insert, update
+  on table aajf.profiles
+  to authenticated;
+
+grant select, insert, update, delete
+  on table aajf.associate_memberships
+  to authenticated;

--- a/supabase/migrations/20260503140000_associate_bootstrap_grants.sql
+++ b/supabase/migrations/20260503140000_associate_bootstrap_grants.sql
@@ -1,0 +1,183 @@
+-- Bootstrap associate access by email.
+-- Associate and admin access remain separate. A person can be one, the other,
+-- or both, and each grant path is managed independently.
+
+create table if not exists aajf.associate_bootstrap_grants (
+  id uuid primary key default gen_random_uuid(),
+  email text not null,
+  normalized_email text generated always as (lower(trim(email))) stored,
+  status text not null default 'pending',
+  membership_status text not null default 'active',
+  claimed_by uuid references aajf.profiles (id) on delete set null,
+  claimed_at timestamptz,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint associate_bootstrap_grants_status_check
+    check (status in ('pending', 'claimed', 'revoked')),
+  constraint associate_bootstrap_grants_membership_status_check
+    check (membership_status in ('active', 'inactive', 'suspended')),
+  constraint associate_bootstrap_grants_normalized_email_unique unique (normalized_email)
+);
+
+create index if not exists associate_bootstrap_grants_status_idx
+  on aajf.associate_bootstrap_grants (status);
+
+drop trigger if exists set_associate_bootstrap_grants_updated_at
+  on aajf.associate_bootstrap_grants;
+
+create trigger set_associate_bootstrap_grants_updated_at
+before update on aajf.associate_bootstrap_grants
+for each row execute function aajf.set_updated_at();
+
+alter table aajf.associate_bootstrap_grants enable row level security;
+
+create policy "associate_bootstrap_grants_select_admin_only"
+on aajf.associate_bootstrap_grants
+for select
+to authenticated
+using (app_private.is_active_admin(auth.uid()));
+
+create policy "associate_bootstrap_grants_write_admin_only"
+on aajf.associate_bootstrap_grants
+for all
+to authenticated
+using (app_private.is_active_admin(auth.uid()))
+with check (app_private.is_active_admin(auth.uid()));
+
+grant select, insert, update, delete
+  on table aajf.associate_bootstrap_grants
+  to authenticated;
+
+create or replace function app_private.apply_associate_bootstrap_to_user(target_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  target_user record;
+  bootstrap_grant record;
+  target_email text;
+  target_full_name text;
+begin
+  select
+    users.id,
+    users.email,
+    users.raw_user_meta_data
+  into target_user
+  from auth.users
+  where users.id = target_user_id;
+
+  if target_user.id is null or target_user.email is null then
+    return;
+  end if;
+
+  target_email := lower(trim(target_user.email));
+  target_full_name := coalesce(
+    target_user.raw_user_meta_data ->> 'full_name',
+    target_user.raw_user_meta_data ->> 'name'
+  );
+
+  insert into aajf.profiles (id, email, full_name)
+  values (target_user.id, target_user.email, target_full_name)
+  on conflict (id) do update
+    set email = excluded.email,
+        full_name = coalesce(excluded.full_name, aajf.profiles.full_name),
+        updated_at = now();
+
+  select *
+  into bootstrap_grant
+  from aajf.associate_bootstrap_grants
+  where normalized_email = target_email
+    and status = 'pending'
+  limit 1;
+
+  if bootstrap_grant.id is null then
+    return;
+  end if;
+
+  insert into aajf.associate_memberships (profile_id, status, notes)
+  values (target_user.id, bootstrap_grant.membership_status, bootstrap_grant.notes)
+  on conflict (profile_id) do update
+    set status = excluded.status,
+        notes = excluded.notes,
+        updated_at = now();
+
+  insert into aajf.associate_profiles (profile_id, full_name)
+  values (
+    target_user.id,
+    coalesce(target_full_name, split_part(target_user.email, '@', 1))
+  )
+  on conflict (profile_id) do update
+    set full_name = coalesce(aajf.associate_profiles.full_name, excluded.full_name),
+        updated_at = now();
+
+  update aajf.associate_bootstrap_grants
+  set status = 'claimed',
+      claimed_by = target_user.id,
+      claimed_at = now()
+  where id = bootstrap_grant.id;
+end;
+$$;
+
+revoke all on function app_private.apply_associate_bootstrap_to_user(uuid)
+  from public, anon, authenticated;
+
+create or replace function app_private.handle_auth_user_associate_bootstrap()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  perform app_private.apply_associate_bootstrap_to_user(new.id);
+  return new;
+end;
+$$;
+
+revoke all on function app_private.handle_auth_user_associate_bootstrap()
+  from public, anon, authenticated;
+
+drop trigger if exists on_auth_user_associate_bootstrap on auth.users;
+
+create trigger on_auth_user_associate_bootstrap
+after insert or update of email on auth.users
+for each row execute function app_private.handle_auth_user_associate_bootstrap();
+
+create or replace function app_private.handle_associate_bootstrap_grant_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  existing_user_id uuid;
+begin
+  if new.status <> 'pending' then
+    return new;
+  end if;
+
+  select users.id
+  into existing_user_id
+  from auth.users
+  where lower(trim(users.email)) = new.normalized_email
+  limit 1;
+
+  if existing_user_id is not null then
+    perform app_private.apply_associate_bootstrap_to_user(existing_user_id);
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function app_private.handle_associate_bootstrap_grant_change()
+  from public, anon, authenticated;
+
+drop trigger if exists on_associate_bootstrap_grant_change
+  on aajf.associate_bootstrap_grants;
+
+create trigger on_associate_bootstrap_grant_change
+after insert or update of email, status on aajf.associate_bootstrap_grants
+for each row execute function app_private.handle_associate_bootstrap_grant_change();

--- a/supabase/migrations/20260503153000_associate_profile_photos_bucket.sql
+++ b/supabase/migrations/20260503153000_associate_profile_photos_bucket.sql
@@ -1,0 +1,19 @@
+insert into storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types
+)
+values (
+  'associate-profile-photos',
+  'associate-profile-photos',
+  false,
+  5242880,
+  array['image/jpeg', 'image/png', 'image/webp']
+)
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;


### PR DESCRIPTION
## Resumo

- implementa a ficha funcional da área do associado
- adiciona validações de obrigatoriedade, CPF e telefone
- habilita busca automática de endereço por CEP
- exige aceite do termo para liberar o salvamento
- habilita upload e persistência da foto do associado no Supabase Storage
- adiciona geração e download da carteirinha do associado em PNG
- ajusta a visualização da carteirinha por modal
- separa corretamente o fluxo de associado do fluxo administrativo
- implementa a concessão de vínculo de associado por email no módulo administrativo
- adiciona grid inicial de consulta de associados com filtros e paginação
- cria grants, tabelas auxiliares e bucket necessários no Supabase
- atualiza a documentação de especificação das issues `#7` e `#8`

## Validação local

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`

## Validação funcional

- [x] `/associado` salva a ficha no banco
- [x] o botão de salvar depende do aceite do termo
- [x] CPF e telefone têm máscara
- [x] CEP preenche endereço automaticamente
- [x] upload da foto persiste no cadastro
- [x] carteirinha pode ser visualizada e baixada em PNG
- [x] `/admin/associados` usa concessão de acesso por email
- [x] existe base de consulta de associados com filtros e paginação
- [ ] validar fluxo completo em Preview
- [ ] validar concessão ponta a ponta de novo associado

## Observações

- esta branch consolidou mudanças das issues `#7` e `#8`
- a área do associado e a gestão administrativa de associados agora estão conectadas ao Supabase
- a carteirinha ainda pode receber refinamentos visuais em outra branch, mas o fluxo funcional já está em pé
- o escopo desta branch cresceu bastante; o objetivo deste merge é encerrar essa frente e retomar em branches menores

## Issues

- `#7`
- `#8`
