### PR TITLE
Chore/UI copy cleanup

### DIFF
--- a/src/app/admin/associados/page.tsx
+++ b/src/app/admin/associados/page.tsx
@@ -25,12 +25,11 @@ export default async function AdminAssociadosPage() {
   return (
     <AdminAccessPanel
       access={access}
-      authorizedDescription="Este módulo agora concede vínculo de associado, permite revisar status e cria a ponte operacional com a área do associado e a ficha cadastral persistida."
+      authorizedDescription=""
       authorizedTitle="Gestão de associados e ficha cadastral"
     >
       {authorizedData ? (
         <AdminAssociatesManager
-          bootstrapGrants={authorizedData.bootstrapGrants}
           memberships={authorizedData.memberships}
         />
       ) : null}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -16,48 +16,34 @@ export default async function AdminPage() {
       authorizedDescription={`Seu acesso administrativo está ativo como ${access.status === "authorized" ? access.role : "administrador"}. Esta área agora funciona como hub inicial para gerir associados, status, permissões e comunicação interna.`}
       authorizedTitle="Bem-vindo à administração."
     >
-      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(17rem,0.8fr)]">
-        <div className="grid gap-5 md:grid-cols-2">
-          <Link
-            className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6 transition hover:-translate-y-0.5"
-            href="/admin/associados"
-          >
-            <p className="section-eyebrow">Módulo</p>
-            <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-              Associados e status
-            </h3>
-            <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-              Preparado para concessão de acesso, leitura de vínculo e gestão
-              do estado de cada associado.
-            </p>
-          </Link>
-
-          <Link
-            className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6 transition hover:-translate-y-0.5"
-            href="/admin/permissoes"
-          >
-            <p className="section-eyebrow">Módulo</p>
-            <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-              Permissões
-            </h3>
-            <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-              Reservado para papéis administrativos, regras de governança e
-              expansão da autorização por perfil.
-            </p>
-          </Link>
-        </div>
-
-        <aside className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-[rgba(255,248,239,0.82)] p-6">
-          <p className="section-eyebrow">Estado Inicial</p>
+      <div className="grid gap-5 md:grid-cols-2">
+        <Link
+          className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6 transition hover:-translate-y-0.5"
+          href="/admin/associados"
+        >
+          <p className="section-eyebrow">Módulo</p>
           <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-            Painel pronto para expansão
+            Associados e status
           </h3>
           <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-            A área administrativa já possui ponto de entrada dedicado,
-            navegação interna e contexto para receber os próximos módulos do
-            sistema sem depender da landing page pública.
+            Preparado para concessão de acesso, leitura de vínculo e gestão
+            do estado de cada associado.
           </p>
-        </aside>
+        </Link>
+
+        <Link
+          className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6 transition hover:-translate-y-0.5"
+          href="/admin/permissoes"
+        >
+          <p className="section-eyebrow">Módulo</p>
+          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
+            Permissões
+          </h3>
+          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
+            Reservado para papéis administrativos, regras de governança e
+            expansão da autorização por perfil.
+          </p>
+        </Link>
       </div>
     </AdminAccessPanel>
   );

--- a/src/app/admin/permissoes/page.test.tsx
+++ b/src/app/admin/permissoes/page.test.tsx
@@ -56,13 +56,6 @@ describe("AdminPermissoesPage", () => {
           status: "pending",
         },
       ],
-      eligibleProfiles: [
-        {
-          email: "perfil@example.com",
-          fullName: "Pessoa de Teste",
-          id: "profile-1",
-        },
-      ],
       memberships: [
         {
           grantedAt: "2026-04-30T12:00:00.000Z",
@@ -97,7 +90,7 @@ describe("AdminPermissoesPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/novo-admin@example.com/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Conceder acesso/i }),
+      screen.getByRole("button", { name: /Autorizar e gerar link/i }),
     ).toBeInTheDocument();
   });
 });

--- a/src/app/admin/permissoes/page.tsx
+++ b/src/app/admin/permissoes/page.tsx
@@ -27,7 +27,6 @@ export default async function AdminPermissoesPage() {
           bootstrapGrants={authorizedData.bootstrapGrants}
           currentAdminProfileId={authorizedData.access.profileId}
           currentAdminRole={authorizedData.access.role}
-          eligibleProfiles={authorizedData.eligibleProfiles}
           memberships={authorizedData.memberships}
         />
       ) : null}

--- a/src/components/admin-access-panel.tsx
+++ b/src/components/admin-access-panel.tsx
@@ -21,9 +21,11 @@ export function AdminAccessPanel({
         <>
           <p className="section-eyebrow">Módulo Administrativo</p>
           <h2 className="section-title mt-4 max-w-3xl">{authorizedTitle}</h2>
-          <p className="section-description mt-6 max-w-2xl">
-            {authorizedDescription}
-          </p>
+          {authorizedDescription ? (
+            <p className="section-description mt-6 max-w-2xl">
+              {authorizedDescription}
+            </p>
+          ) : null}
           {access.email ? (
             <p className="mt-5 text-base font-medium text-[var(--color-green-deep)]">
               Conta conectada: {access.email}

--- a/src/components/admin-associates-manager.tsx
+++ b/src/components/admin-associates-manager.tsx
@@ -6,24 +6,18 @@ import {
   updateAssociateMembership,
   type AdminAssociatesActionState,
 } from "@/app/admin/associados/actions";
-import type {
-  AdminAssociateMembershipRecord,
-  AssociateBootstrapGrantRecord,
-} from "@/lib/supabase/admin-associates";
+import type { AdminAssociateMembershipRecord } from "@/lib/supabase/admin-associates";
 
 const initialState: AdminAssociatesActionState = {};
 const PAGE_SIZE = 5;
 
 type AdminAssociatesManagerProps = {
-  bootstrapGrants: AssociateBootstrapGrantRecord[];
   memberships: AdminAssociateMembershipRecord[];
 };
 
 export function AdminAssociatesManager({
-  bootstrapGrants = [],
   memberships = [],
 }: AdminAssociatesManagerProps) {
-  const safeBootstrapGrants = Array.isArray(bootstrapGrants) ? bootstrapGrants : [];
   const safeMemberships = Array.isArray(memberships) ? memberships : [];
   const [grantState, grantAction, isGranting] = useActionState(
     grantAssociateAccess,
@@ -40,8 +34,7 @@ export function AdminAssociatesManager({
     const matchesQuery =
       !normalizedQuery ||
       membership.profile.email.toLowerCase().includes(normalizedQuery) ||
-      (membership.profile.fullName || "").toLowerCase().includes(normalizedQuery) ||
-      (membership.notes || "").toLowerCase().includes(normalizedQuery);
+      (membership.profile.fullName || "").toLowerCase().includes(normalizedQuery);
 
     const matchesStatus =
       statusFilter === "all" || membership.status === statusFilter;
@@ -64,19 +57,10 @@ export function AdminAssociatesManager({
       <section className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(20rem,0.95fr)]">
         <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
           <p className="section-eyebrow">Associados atuais</p>
-          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-            Quem já possui vínculo com a associação
-          </h3>
-          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-            Esta lista já usa `associate_memberships` e o espelho inicial da
-            ficha cadastral para facilitar consulta, status e preparação da área
-            do associado.
-          </p>
-
-          <div className="mt-6 grid gap-4">
+          <div className="mt-4 grid gap-4">
             <div className="grid gap-4 rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,250,243,0.72)] p-4 lg:grid-cols-3">
               <label className="form-field">
-                <span>Buscar por nome, email ou observação</span>
+                <span>Buscar por nome ou email</span>
                 <input
                   onChange={(event) => {
                     setQuery(event.target.value);
@@ -115,9 +99,14 @@ export function AdminAssociatesManager({
                   value={categoryFilter}
                 >
                   <option value="all">Todas</option>
+                  <option value="Kindergarten">Kindergarten</option>
                   <option value="Kleine Kinder">Kleine Kinder</option>
-                  <option value="Gosse Kinder">Gosse Kinder</option>
+                  <option value="Grosse Kinder">Grosse Kinder</option>
+                  <option value="Jugendliche">Jugendliche</option>
+                  <option value="Erwachsene">Erwachsene</option>
                   <option value="Heimweh">Heimweh</option>
+                  <option value="Senioren">Senioren</option>
+                  <option value="Männertanz">Männertanz</option>
                   <option value="none">Nao definida</option>
                 </select>
               </label>
@@ -125,8 +114,8 @@ export function AdminAssociatesManager({
 
             {filteredMemberships.length ? (
               <>
-                <div className="overflow-x-auto rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-white/72">
-                  <div className="hidden min-w-[72rem] grid-cols-[1.2fr_1.25fr_0.85fr_1fr_1fr_1.2fr] gap-4 border-b border-[rgba(23,54,45,0.08)] px-5 py-4 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--color-red)] lg:grid">
+                <div className="rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-white/72">
+                  <div className="hidden grid-cols-[minmax(11rem,1.3fr)_minmax(12rem,1.25fr)_minmax(7rem,0.8fr)_minmax(8rem,0.9fr)_minmax(9rem,0.9fr)_minmax(8.5rem,0.95fr)] gap-4 border-b border-[rgba(23,54,45,0.08)] px-5 py-3 text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--color-red)] lg:grid">
                     <span>Nome</span>
                     <span>Email</span>
                     <span>Categoria</span>
@@ -227,52 +216,6 @@ export function AdminAssociatesManager({
           </form>
         </article>
       </section>
-
-      <section className="grid gap-5">
-        <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
-          <p className="section-eyebrow">Concessões por email</p>
-          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-            Quem já foi autorizado a entrar como associado
-          </h3>
-          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-            Esta lista usa `associate_bootstrap_grants` para registrar a
-            autorização por email e preparar o primeiro acesso do associado.
-          </p>
-
-          <div className="mt-6 grid gap-4">
-            {safeBootstrapGrants.length ? (
-              safeBootstrapGrants.map((grant) => (
-                <div
-                  className="rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,255,255,0.7)] p-5"
-                  key={grant.id}
-                >
-                  <p className="text-base font-semibold text-[var(--color-green-deep)]">
-                    {grant.email}
-                  </p>
-                  <div className="mt-4 flex flex-wrap gap-3">
-                    <InfoChip label="Grant" value={grant.status} />
-                    <InfoChip label="Vínculo previsto" value={grant.membershipStatus} />
-                    <InfoChip
-                      label="Claim"
-                      value={grant.claimedAt ? formatDateTime(grant.claimedAt) : "Ainda não"}
-                    />
-                  </div>
-                  {grant.notes ? (
-                    <p className="mt-4 text-sm leading-7 text-[var(--color-muted)]">
-                      {grant.notes}
-                    </p>
-                  ) : null}
-                </div>
-              ))
-            ) : (
-              <p className="text-sm leading-7 text-[var(--color-muted)]">
-                Nenhuma autorização de associado por email foi registrada até o
-                momento.
-              </p>
-            )}
-          </div>
-        </article>
-      </section>
     </div>
   );
 }
@@ -286,68 +229,172 @@ function AssociateMembershipRow({
     updateAssociateMembership,
     initialState,
   );
+  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
 
   return (
-    <form
-      action={action}
-      className="min-w-[72rem] border-b border-[rgba(23,54,45,0.08)] bg-[rgba(255,255,255,0.7)] px-5 py-5 last:border-b-0"
-    >
-      <input name="membershipId" type="hidden" value={membership.id} />
+    <>
+      <form
+        action={action}
+        className="border-b border-[rgba(23,54,45,0.08)] bg-[rgba(255,255,255,0.7)] px-5 py-4 last:border-b-0"
+      >
+        <input name="membershipId" type="hidden" value={membership.id} />
+        <input name="notes" type="hidden" value={membership.notes || ""} />
 
-      <div className="grid gap-4 lg:grid-cols-[1.2fr_1.25fr_0.85fr_1fr_1fr_1.2fr] lg:items-start">
-        <div className="max-w-2xl">
-          <p className="text-base font-semibold text-[var(--color-green-deep)]">
-            {membership.profile.fullName || "Sem nome informado"}
-          </p>
-          <p className="mt-3 text-xs uppercase tracking-[0.18em] text-[var(--color-red)]">
-            Concedido em {formatDateTime(membership.grantedAt)}
-          </p>
-        </div>
+        <div className="grid gap-4 lg:grid-cols-[minmax(11rem,1.3fr)_minmax(12rem,1.25fr)_minmax(7rem,0.8fr)_minmax(8rem,0.9fr)_minmax(9rem,0.9fr)_minmax(8.5rem,0.95fr)] lg:items-start">
+          <div className="min-w-0">
+            <p className="text-[1.05rem] font-semibold leading-7 text-[var(--color-green-deep)]">
+              {membership.profile.fullName || "Sem nome informado"}
+            </p>
+            <p className="mt-2 text-[0.7rem] uppercase tracking-[0.16em] text-[var(--color-red)]">
+              Concedido em {formatDateTime(membership.grantedAt)}
+            </p>
+          </div>
 
-        <div className="text-sm leading-7 text-[var(--color-muted)]">
-          {membership.profile.email}
-        </div>
+          <div className="min-w-0 break-words text-[0.95rem] leading-7 text-[var(--color-muted)]">
+            {membership.profile.email}
+          </div>
 
-        <div className="text-sm leading-7 text-[var(--color-muted)]">
-          {membership.profileSnapshot?.category || "Nao definida"}
-        </div>
+          <div className="text-[0.95rem] leading-7 text-[var(--color-muted)]">
+            {membership.profileSnapshot?.category || "Nao definida"}
+          </div>
 
-        <div className="text-sm leading-7 text-[var(--color-muted)]">
-          {membership.profileSnapshot?.phone || "Nao informado"}
-        </div>
+          <div className="text-[0.95rem] leading-7 text-[var(--color-muted)]">
+            {membership.profileSnapshot?.phone || "Nao informado"}
+          </div>
 
-        <div className="grid gap-3">
-          <label className="form-field">
-            <span className="lg:sr-only">Status</span>
-            <select
-              className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-[rgba(255,250,243,0.88)] px-4 py-3 text-[var(--color-ink)]"
-              defaultValue={membership.status}
-              name="status"
+          <div className="grid gap-2">
+            <label className="form-field">
+              <span className="lg:sr-only">Status</span>
+              <select
+                className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-[rgba(255,250,243,0.88)] px-3 py-2.5 text-[0.95rem] text-[var(--color-ink)]"
+                defaultValue={membership.status}
+                name="status"
+              >
+                <option value="active">active</option>
+                <option value="inactive">inactive</option>
+                <option value="suspended">suspended</option>
+              </select>
+            </label>
+            <ActionFeedback state={state} />
+          </div>
+
+          <div className="grid gap-2">
+            <button
+              className="rounded-full border border-[rgba(23,54,45,0.14)] bg-white px-4 py-2.5 text-[0.95rem] font-medium text-[var(--color-green-deep)] transition hover:bg-[rgba(255,250,243,0.92)]"
+              onClick={() => setIsDetailsOpen(true)}
+              type="button"
             >
-              <option value="active">active</option>
-              <option value="inactive">inactive</option>
-              <option value="suspended">suspended</option>
-            </select>
-          </label>
-          <ActionFeedback state={state} />
+              Ver dados
+            </button>
+            <button
+              className="rounded-full border border-[rgba(23,54,45,0.14)] bg-white px-4 py-2.5 text-[0.95rem] font-medium text-[var(--color-green-deep)] transition hover:bg-[rgba(255,250,243,0.92)] disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isPending}
+              type="submit"
+            >
+              {isPending ? "Salvando..." : "Atualizar vínculo"}
+            </button>
+          </div>
         </div>
+      </form>
 
-        <div className="grid gap-3">
-          <label className="form-field">
-            <span className="lg:sr-only">Observações administrativas</span>
-            <textarea
-              className="min-h-24"
-              defaultValue={membership.notes || ""}
-              name="notes"
-              placeholder="Observações internas sobre este vínculo."
-            />
-          </label>
-          <button className="secondary-button" disabled={isPending} type="submit">
-            {isPending ? "Salvando..." : "Atualizar vínculo"}
-          </button>
+      {isDetailsOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,23,20,0.62)] px-4 py-6">
+          <div className="w-full max-w-2xl rounded-[2rem] border border-white/60 bg-[rgba(255,250,243,0.98)] p-6 shadow-[0_24px_80px_rgba(9,28,22,0.28)]">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="section-eyebrow">Dados do associado</p>
+                <h3 className="mt-3 text-3xl font-heading text-[var(--color-green-deep)]">
+                  {membership.profile.fullName || "Sem nome informado"}
+                </h3>
+              </div>
+              <button
+                aria-label="Fechar dados do associado"
+                className="grid h-10 w-10 place-items-center rounded-full border border-[rgba(23,54,45,0.12)] bg-white text-lg text-[var(--color-green-deep)] transition hover:bg-[rgba(255,250,243,0.92)]"
+                onClick={() => setIsDetailsOpen(false)}
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+
+            <div className="mt-8 rounded-[1.5rem] border border-[rgba(23,54,45,0.1)] bg-white/80 p-5">
+              <div className="grid gap-6 text-sm leading-7 text-[var(--color-green-deep)]">
+                <div className="grid gap-2">
+                  <p><strong>Email:</strong> {membership.profile.email}</p>
+                  <p><strong>Status do vínculo:</strong> {membership.status}</p>
+                  <p><strong>Concedido em:</strong> {formatDateTime(membership.grantedAt)}</p>
+                  <p><strong>Observações administrativas:</strong> {membership.notes || "Nenhuma observação registrada."}</p>
+                </div>
+
+                <div className="grid gap-2">
+                  <p><strong>Nome completo:</strong> {membership.profileSnapshot?.fullName || membership.profile.fullName || "Não informado"}</p>
+                  <p><strong>Categoria:</strong> {membership.profileSnapshot?.category || "Não definida"}</p>
+                  <p><strong>CPF:</strong> {membership.profileSnapshot?.cpf || "Não informado"}</p>
+                  <p><strong>RG:</strong> {membership.profileSnapshot?.rg || "Não informado"}</p>
+                  <p><strong>Telefone:</strong> {membership.profileSnapshot?.phone || "Não informado"}</p>
+                  <p><strong>Data de nascimento:</strong> {formatDate(membership.profileSnapshot?.birthDate)}</p>
+                  <p><strong>Nacionalidade:</strong> {membership.profileSnapshot?.nationality || "Não informada"}</p>
+                </div>
+
+                <div className="grid gap-2">
+                  <p><strong>CEP:</strong> {membership.profileSnapshot?.cep || "Não informado"}</p>
+                  <p><strong>Rua:</strong> {membership.profileSnapshot?.addressStreet || "Não informada"}</p>
+                  <p><strong>Número:</strong> {membership.profileSnapshot?.addressNumber || "Não informado"}</p>
+                  <p><strong>Complemento:</strong> {membership.profileSnapshot?.addressComplement || "Não informado"}</p>
+                  <p><strong>Bairro:</strong> {membership.profileSnapshot?.addressNeighborhood || "Não informado"}</p>
+                  <p><strong>Cidade:</strong> {membership.profileSnapshot?.addressCity || "Não informada"}</p>
+                  <p><strong>UF:</strong> {membership.profileSnapshot?.addressState || "Não informada"}</p>
+                </div>
+
+                <div className="grid gap-2">
+                  <p><strong>Observação do associado:</strong> {membership.profileSnapshot?.observation || "Nenhuma observação informada."}</p>
+                  <p><strong>Termo aceito:</strong> {membership.profileSnapshot?.termAccepted ? "Sim" : "Não"}</p>
+                  <p><strong>Foto cadastrada:</strong> {membership.profileSnapshot?.photoUrl ? "Sim" : "Não"}</p>
+                </div>
+
+                <div className="grid gap-3">
+                  <p className="text-sm font-semibold uppercase tracking-[0.14em] text-[var(--color-red)]">
+                    Dependentes
+                  </p>
+
+                  {membership.profileSnapshot?.dependents.length ? (
+                    <div className="grid gap-4">
+                      {membership.profileSnapshot.dependents.map((dependent, index) => (
+                        <div
+                          className="rounded-[1.2rem] border border-[rgba(23,54,45,0.08)] bg-[rgba(255,250,243,0.7)] p-4"
+                          key={dependent.id}
+                        >
+                          <div className="space-y-2">
+                            <p><strong>Dependente {index + 1}:</strong> {dependent.fullName}</p>
+                            <p><strong>Categoria:</strong> {dependent.category || "Não definida"}</p>
+                            <p><strong>CPF:</strong> {dependent.cpf || "Não informado"}</p>
+                            <p><strong>RG:</strong> {dependent.rg || "Não informado"}</p>
+                            <p><strong>Data de nascimento:</strong> {formatDate(dependent.birthDate)}</p>
+                            <p><strong>Nacionalidade:</strong> {dependent.nationality || "Não informada"}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p>Nenhum dependente cadastrado.</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-6 flex justify-end">
+              <button
+                className="secondary-button"
+                onClick={() => setIsDetailsOpen(false)}
+                type="button"
+              >
+                Fechar
+              </button>
+            </div>
+          </div>
         </div>
-      </div>
-    </form>
+      ) : null}
+    </>
   );
 }
 
@@ -365,17 +412,23 @@ function ActionFeedback({ state }: { state: AdminAssociatesActionState }) {
   return null;
 }
 
-function InfoChip({ label, value }: { label: string; value: string }) {
-  return (
-    <span className="rounded-full border border-[rgba(23,54,45,0.12)] bg-[rgba(255,250,243,0.82)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--color-green-deep)]">
-      {label}: {value}
-    </span>
-  );
-}
-
 function formatDateTime(value: string) {
   return new Intl.DateTimeFormat("pt-BR", {
     dateStyle: "short",
     timeStyle: "short",
   }).format(new Date(value));
+}
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return "Não informada";
+  }
+
+  const [year, month, day] = value.split("-");
+
+  if (!year || !month || !day) {
+    return value;
+  }
+
+  return `${day}/${month}/${year}`;
 }

--- a/src/components/admin-permissions-manager.tsx
+++ b/src/components/admin-permissions-manager.tsx
@@ -3,7 +3,6 @@
 import { useActionState } from "react";
 import {
   createAdminBootstrapGrant,
-  grantAdminAccess,
   type AdminPermissionsActionState,
   removeAdminUser,
   updateAdminBootstrapGrant,
@@ -12,7 +11,6 @@ import {
 import type {
   AdminBootstrapGrantRecord,
   AdminMembershipRecord,
-  EligibleAdminProfileRecord,
 } from "@/lib/supabase/admin-permissions";
 
 const initialState: AdminPermissionsActionState = {};
@@ -21,7 +19,6 @@ type AdminPermissionsManagerProps = {
   bootstrapGrants: AdminBootstrapGrantRecord[];
   currentAdminProfileId: string;
   currentAdminRole: string;
-  eligibleProfiles: EligibleAdminProfileRecord[];
   memberships: AdminMembershipRecord[];
 };
 
@@ -29,13 +26,8 @@ export function AdminPermissionsManager({
   bootstrapGrants,
   currentAdminProfileId,
   currentAdminRole,
-  eligibleProfiles,
   memberships,
 }: AdminPermissionsManagerProps) {
-  const [grantAccessState, grantAccessAction, isGrantingAccess] = useActionState(
-    grantAdminAccess,
-    initialState,
-  );
   const [bootstrapState, bootstrapAction, isCreatingBootstrap] = useActionState(
     createAdminBootstrapGrant,
     initialState,
@@ -43,7 +35,7 @@ export function AdminPermissionsManager({
 
   return (
     <div className="grid gap-6">
-      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)]">
+      <section className="grid gap-5">
         <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
           <p className="section-eyebrow">Acessos atuais</p>
           <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
@@ -73,72 +65,6 @@ export function AdminPermissionsManager({
             )}
           </div>
         </article>
-
-        <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-[rgba(255,248,239,0.82)] p-6">
-          <p className="section-eyebrow">Promover perfil existente</p>
-          <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-            Conceder acesso a quem já entrou no sistema
-          </h3>
-          <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-            Use este fluxo quando a pessoa já entrou no sistema e já possui
-            perfil em `aajf.profiles`. Para novos administradores que ainda não
-            entraram, use o convite por email no bloco ao lado.
-          </p>
-
-          <form action={grantAccessAction} className="mt-6 grid gap-4">
-            <label className="form-field">
-              <span>Perfil existente</span>
-              <select
-                className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-white/88 px-4 py-3 text-[var(--color-ink)]"
-                defaultValue=""
-                name="profileId"
-              >
-                <option value="" disabled>
-                  Selecione um perfil
-                </option>
-                {eligibleProfiles.map((profile) => (
-                  <option key={profile.id} value={profile.id}>
-                    {profile.fullName ? `${profile.fullName} - ` : ""}
-                    {profile.email}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <div className="grid gap-4 sm:grid-cols-2">
-              <label className="form-field">
-                <span>Papel</span>
-                <select
-                  className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-white/88 px-4 py-3 text-[var(--color-ink)]"
-                  defaultValue="admin"
-                  name="role"
-                >
-                  <option value="admin">admin</option>
-                  <option value="super_admin">super_admin</option>
-                </select>
-              </label>
-
-              <label className="form-field">
-                <span>Status</span>
-                <select
-                  className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-white/88 px-4 py-3 text-[var(--color-ink)]"
-                  defaultValue="active"
-                  name="status"
-                >
-                  <option value="active">active</option>
-                  <option value="inactive">inactive</option>
-                  <option value="suspended">suspended</option>
-                </select>
-              </label>
-            </div>
-
-            <ActionFeedback state={grantAccessState} />
-
-            <button className="primary-button" disabled={isGrantingAccess} type="submit">
-              {isGrantingAccess ? "Salvando..." : "Conceder acesso"}
-            </button>
-          </form>
-        </article>
       </section>
 
       <section className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(20rem,0.95fr)]">
@@ -148,8 +74,8 @@ export function AdminPermissionsManager({
             Quem vai receber o primeiro acesso por email
           </h3>
           <p className="mt-4 text-sm leading-7 text-[var(--color-green-deep)]">
-            Esta lista usa `admin_bootstrap_grants` para preparar autorização
-            antecipada e registrar quem ainda deve concluir o primeiro acesso.
+            Esta lista mostra quem já foi autorizado a entrar na administração,
+            mas ainda precisa concluir o primeiro acesso.
           </p>
 
           <div className="mt-6 grid gap-4">

--- a/src/components/admin-shell.test.tsx
+++ b/src/components/admin-shell.test.tsx
@@ -10,9 +10,7 @@ describe("AdminShell", () => {
     );
 
     expect(
-      screen.getByRole("heading", {
-        name: /Um painel inicial para organizar gestão, permissões e operação interna/i,
-      }),
+      screen.getByText(/Área Administrativa/i),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("navigation", { name: /Navegação administrativa/i }),

--- a/src/components/admin-shell.tsx
+++ b/src/components/admin-shell.tsx
@@ -1,37 +1,14 @@
 import Link from "next/link";
-import { adminHighlights, adminNavItems } from "@/lib/admin-content";
+import { adminNavItems } from "@/lib/admin-content";
 
 export function AdminShell({ children }: { children: React.ReactNode }) {
   return (
     <main className="section-shell flex-1 pb-16 pt-8">
       <section className="hero-panel rounded-[2rem] p-8 sm:p-10 lg:p-12">
-        <div className="grid gap-8 lg:grid-cols-[minmax(0,1.55fr)_minmax(18rem,0.9fr)] lg:items-start">
-          <div>
-            <p className="section-eyebrow">Área Administrativa</p>
-            <h1 className="section-title mt-4 max-w-3xl">
-              Um painel inicial para organizar gestão, permissões e operação
-              interna.
-            </h1>
-            <p className="section-description mt-6 max-w-2xl">
-              Esta área administrativa agora tem estrutura própria, navegação
-              interna e espaço reservado para os módulos que vão sustentar a
-              operação da associação.
-            </p>
-          </div>
-
-          <div className="grid gap-3">
-            {adminHighlights.map((item) => (
-              <div key={item} className="metric-card">
-                <p className="metric-label">Direção</p>
-                <p className="metric-value">{item}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-
+        <p className="section-eyebrow">Área Administrativa</p>
         <nav
           aria-label="Navegação administrativa"
-          className="mt-8 grid gap-3 md:grid-cols-2 xl:grid-cols-4"
+          className="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-4"
         >
           {adminNavItems.map((item) => (
             <Link

--- a/src/components/associate-area-manager.tsx
+++ b/src/components/associate-area-manager.tsx
@@ -456,8 +456,6 @@ export function AssociateAreaManager({
 
                       <p className="mt-4 text-sm leading-7 text-[var(--color-muted)]">
                         Envie uma foto nítida, em JPG, PNG ou WEBP, com até 5 MB.
-                        O preview ajuda na conferência visual e, ao salvar a ficha,
-                        a imagem passa a ficar persistida no cadastro do associado.
                       </p>
                     </div>
                   </div>
@@ -561,23 +559,6 @@ export function AssociateAreaManager({
                 </div>
 
                 <div className="mt-6 grid gap-4">
-                  <button
-                    className="group flex min-h-36 w-full flex-col items-center justify-center rounded-[1.5rem] border border-dashed border-[rgba(23,54,45,0.18)] bg-[rgba(255,250,243,0.72)] p-6 text-center transition hover:border-[rgba(23,54,45,0.3)] hover:bg-[rgba(255,250,243,0.92)]"
-                    onClick={addDependent}
-                    type="button"
-                  >
-                    <span className="flex h-14 w-14 items-center justify-center rounded-full border border-[rgba(23,54,45,0.14)] bg-white text-3xl font-light text-[var(--color-green-deep)] transition group-hover:scale-105">
-                      +
-                    </span>
-                    <span className="mt-4 text-base font-semibold text-[var(--color-green-deep)]">
-                      Adicionar dependente
-                    </span>
-                    <span className="mt-2 max-w-md text-sm leading-7 text-[var(--color-muted)]">
-                      Use esta área sempre que precisar incluir o primeiro dependente
-                      ou acrescentar novos vínculos na ficha do associado.
-                    </span>
-                  </button>
-
                   {draft.dependents.length ? (
                     draft.dependents.map((dependent, index) => (
                       <div
@@ -673,6 +654,23 @@ export function AssociateAreaManager({
                       use a caixa com o símbolo de + para iniciar essa lista.
                     </div>
                   )}
+
+                  <button
+                    className="group flex min-h-36 w-full flex-col items-center justify-center rounded-[1.5rem] border border-dashed border-[rgba(23,54,45,0.18)] bg-[rgba(255,250,243,0.72)] p-6 text-center transition hover:border-[rgba(23,54,45,0.3)] hover:bg-[rgba(255,250,243,0.92)]"
+                    onClick={addDependent}
+                    type="button"
+                  >
+                    <span className="flex h-14 w-14 items-center justify-center rounded-full border border-[rgba(23,54,45,0.14)] bg-white text-3xl font-light text-[var(--color-green-deep)] transition group-hover:scale-105">
+                      +
+                    </span>
+                    <span className="mt-4 text-base font-semibold text-[var(--color-green-deep)]">
+                      Adicionar dependente
+                    </span>
+                    <span className="mt-2 max-w-md text-sm leading-7 text-[var(--color-muted)]">
+                      Use esta área sempre que precisar incluir o primeiro dependente
+                      ou acrescentar novos vínculos na ficha do associado.
+                    </span>
+                  </button>
                 </div>
               </div>
 

--- a/src/lib/admin-content.ts
+++ b/src/lib/admin-content.ts
@@ -20,9 +20,3 @@ export const adminNavItems = [
     description: "Organização futura de avisos, publicações e recados internos.",
   },
 ];
-
-export const adminHighlights = [
-  "Gestão centralizada do acesso",
-  "Estrutura pronta para crescer por módulos",
-  "Responsiva para uso administrativo inicial",
-];

--- a/src/lib/supabase/admin-associates.ts
+++ b/src/lib/supabase/admin-associates.ts
@@ -1,6 +1,16 @@
 import { getAdminAccess, type AdminAccess } from "@/lib/supabase/access";
-import type { AssociateCategory } from "@/lib/supabase/associate-profile-shared";
+import type {
+  AssociateCategory,
+  AssociateDependentRecord,
+  AssociateProfileRecord,
+  Nationality,
+} from "@/lib/supabase/associate-profile-shared";
 import { createClient } from "@/lib/supabase/server";
+
+type AdminAssociateProfileSnapshot = Omit<
+  AssociateProfileRecord,
+  "email" | "profileId"
+>;
 
 export type AdminAssociateMembershipRecord = {
   grantedAt: string;
@@ -11,10 +21,7 @@ export type AdminAssociateMembershipRecord = {
     fullName: string | null;
     id: string;
   };
-  profileSnapshot: {
-    category: AssociateCategory | null;
-    phone: string | null;
-  } | null;
+  profileSnapshot: AdminAssociateProfileSnapshot | null;
   status: "active" | "inactive" | "suspended";
 };
 
@@ -45,8 +52,8 @@ export async function getAdminAssociatesData(): Promise<AdminAssociatesData> {
   const supabase = await createClient();
   const [
     { data: membershipsData, error: membershipsError },
-    { data: grantsData, error: grantsError },
     { data: associateProfilesData, error: associateProfilesError },
+    { data: associateDependentsData, error: associateDependentsError },
   ] =
     await Promise.all([
       supabase
@@ -58,29 +65,70 @@ export async function getAdminAssociatesData(): Promise<AdminAssociatesData> {
         .order("granted_at", { ascending: false }),
       supabase
         .schema("aajf")
-        .from("associate_bootstrap_grants")
-        .select("id, email, status, membership_status, claimed_at, notes")
-        .order("created_at", { ascending: false }),
+        .from("associate_profiles")
+        .select(
+          "id, profile_id, full_name, category, cpf, rg, phone, birth_date, nationality, cep, street, number, complement, neighborhood, city, state, observation, term_accepted, photo_url",
+        ),
       supabase
         .schema("aajf")
-        .from("associate_profiles")
-        .select("profile_id, category, phone"),
+        .from("associate_dependents")
+        .select(
+          "id, associate_profile_id, full_name, category, cpf, rg, birth_date, nationality",
+        ),
     ]);
 
   if (membershipsError) {
     throw membershipsError;
   }
 
-  if (grantsError) {
-    throw grantsError;
-  }
-
   if (associateProfilesError) {
     throw associateProfilesError;
   }
 
+  if (associateDependentsError) {
+    throw associateDependentsError;
+  }
+
+  const dependentsByAssociateProfileId = new Map<string, AssociateDependentRecord[]>();
+
+  for (const dependent of associateDependentsData ?? []) {
+    const entry = dependentsByAssociateProfileId.get(dependent.associate_profile_id) ?? [];
+    entry.push({
+      birthDate: dependent.birth_date ?? "",
+      category: dependent.category as AssociateCategory | null,
+      cpf: dependent.cpf,
+      fullName: dependent.full_name,
+      id: dependent.id,
+      nationality: dependent.nationality as Nationality | null,
+      rg: dependent.rg,
+    });
+    dependentsByAssociateProfileId.set(dependent.associate_profile_id, entry);
+  }
+
   const associateProfilesByProfileId = new Map(
-    (associateProfilesData ?? []).map((profile) => [profile.profile_id, profile]),
+    (associateProfilesData ?? []).map((profile) => [
+      profile.profile_id,
+      {
+        addressCity: profile.city ?? "",
+        addressComplement: profile.complement ?? "",
+        addressNeighborhood: profile.neighborhood ?? "",
+        addressNumber: profile.number ?? "",
+        addressState: profile.state ?? "",
+        addressStreet: profile.street ?? "",
+        birthDate: profile.birth_date ?? "",
+        category: profile.category as AssociateCategory | null,
+        cep: profile.cep ?? "",
+        cpf: profile.cpf ?? "",
+        dependents: dependentsByAssociateProfileId.get(profile.id) ?? [],
+        fullName: profile.full_name ?? "",
+        nationality: profile.nationality as Nationality | null,
+        observation: profile.observation ?? "",
+        phone: profile.phone ?? "",
+        photoUrl: profile.photo_url,
+        rg: profile.rg ?? "",
+        termAccepted: profile.term_accepted ?? false,
+      } satisfies AdminAssociateProfileSnapshot,
+    ]),
   );
 
   const memberships: AdminAssociateMembershipRecord[] = (membershipsData ?? [])
@@ -103,31 +151,15 @@ export async function getAdminAssociatesData(): Promise<AdminAssociatesData> {
           fullName: profile.full_name,
           id: profile.id,
         },
-        profileSnapshot: associateProfile
-          ? {
-              category: associateProfile.category,
-              phone: associateProfile.phone,
-            }
-          : null,
+        profileSnapshot: associateProfile ?? null,
         status: membership.status,
       } as AdminAssociateMembershipRecord;
     })
     .filter((membership): membership is AdminAssociateMembershipRecord => membership !== null);
 
-  const bootstrapGrants: AssociateBootstrapGrantRecord[] = (grantsData ?? []).map(
-    (grant) => ({
-      claimedAt: grant.claimed_at,
-      email: grant.email,
-      id: grant.id,
-      membershipStatus: grant.membership_status,
-      notes: grant.notes,
-      status: grant.status,
-    }),
-  );
-
   return {
     access,
-    bootstrapGrants,
+    bootstrapGrants: [],
     memberships,
   };
 }

--- a/src/lib/supabase/admin-permissions.ts
+++ b/src/lib/supabase/admin-permissions.ts
@@ -22,18 +22,11 @@ export type AdminBootstrapGrantRecord = {
   status: "pending" | "claimed" | "revoked";
 };
 
-export type EligibleAdminProfileRecord = {
-  email: string;
-  fullName: string | null;
-  id: string;
-};
-
 export type AdminPermissionsData =
   | { access: Extract<AdminAccess, { status: "unconfigured" | "unauthenticated" | "denied" }> }
   | {
       access: Extract<AdminAccess, { status: "authorized" }>;
       bootstrapGrants: AdminBootstrapGrantRecord[];
-      eligibleProfiles: EligibleAdminProfileRecord[];
       memberships: AdminMembershipRecord[];
     };
 
@@ -46,7 +39,7 @@ export async function getAdminPermissionsData(): Promise<AdminPermissionsData> {
 
   const supabase = await createClient();
 
-  const [{ data: membershipsData, error: membershipsError }, { data: grantsData, error: grantsError }, { data: profilesData, error: profilesError }] =
+  const [{ data: membershipsData, error: membershipsError }, { data: grantsData, error: grantsError }] =
     await Promise.all([
       supabase
         .schema("aajf")
@@ -58,11 +51,6 @@ export async function getAdminPermissionsData(): Promise<AdminPermissionsData> {
         .from("admin_bootstrap_grants")
         .select("id, email, role, status, claimed_at, notes")
         .order("created_at", { ascending: false }),
-      supabase
-        .schema("aajf")
-        .from("profiles")
-        .select("id, email, full_name")
-        .order("created_at", { ascending: false }),
     ]);
 
   if (membershipsError) {
@@ -71,10 +59,6 @@ export async function getAdminPermissionsData(): Promise<AdminPermissionsData> {
 
   if (grantsError) {
     throw grantsError;
-  }
-
-  if (profilesError) {
-    throw profilesError;
   }
 
   const memberships: AdminMembershipRecord[] = (membershipsData ?? [])
@@ -112,20 +96,9 @@ export async function getAdminPermissionsData(): Promise<AdminPermissionsData> {
     }),
   );
 
-  const memberProfileIds = new Set(memberships.map((membership) => membership.profile.id));
-
-  const eligibleProfiles: EligibleAdminProfileRecord[] = (profilesData ?? [])
-    .filter((profile) => !memberProfileIds.has(profile.id))
-    .map((profile) => ({
-      email: profile.email,
-      fullName: profile.full_name,
-      id: profile.id,
-    }));
-
   return {
     access,
     bootstrapGrants,
-    eligibleProfiles,
     memberships,
   };
 }

--- a/src/lib/supabase/associate-profile-shared.ts
+++ b/src/lib/supabase/associate-profile-shared.ts
@@ -7,9 +7,14 @@ export const associatePhotoAcceptedMimeTypes = [
 export const associatePhotoMaxFileSizeInBytes = 5 * 1024 * 1024;
 
 export const associateCategoryOptions = [
+  "Kindergarten",
   "Kleine Kinder",
-  "Gosse Kinder",
+  "Grosse Kinder",
+  "Jugendliche",
+  "Erwachsene",
   "Heimweh",
+  "Senioren",
+  "Männertanz",
 ] as const;
 
 export const nationalityOptions = [

--- a/supabase/migrations/20260504150000_expand_associate_categories.sql
+++ b/supabase/migrations/20260504150000_expand_associate_categories.sql
@@ -1,0 +1,73 @@
+alter table aajf.associate_profiles
+  drop constraint if exists associate_profiles_category_check;
+
+alter table aajf.associate_dependents
+  drop constraint if exists associate_dependents_category_check;
+
+update aajf.associate_profiles
+set category = 'Grosse Kinder'
+where category = 'Gosse Kinder';
+
+update aajf.associate_dependents
+set category = 'Grosse Kinder'
+where category = 'Gosse Kinder';
+
+update aajf.associate_profiles
+set category = null
+where category is not null
+  and category not in (
+    'Kindergarten',
+    'Kleine Kinder',
+    'Grosse Kinder',
+    'Jugendliche',
+    'Erwachsene',
+    'Heimweh',
+    'Senioren',
+    'Männertanz'
+  );
+
+update aajf.associate_dependents
+set category = null
+where category is not null
+  and category not in (
+    'Kindergarten',
+    'Kleine Kinder',
+    'Grosse Kinder',
+    'Jugendliche',
+    'Erwachsene',
+    'Heimweh',
+    'Senioren',
+    'Männertanz'
+  );
+
+alter table aajf.associate_profiles
+  add constraint associate_profiles_category_check
+  check (
+    category is null
+    or category in (
+      'Kindergarten',
+      'Kleine Kinder',
+      'Grosse Kinder',
+      'Jugendliche',
+      'Erwachsene',
+      'Heimweh',
+      'Senioren',
+      'Männertanz'
+    )
+  );
+
+alter table aajf.associate_dependents
+  add constraint associate_dependents_category_check
+  check (
+    category is null
+    or category in (
+      'Kindergarten',
+      'Kleine Kinder',
+      'Grosse Kinder',
+      'Jugendliche',
+      'Erwachsene',
+      'Heimweh',
+      'Senioren',
+      'Männertanz'
+    )
+  );


### PR DESCRIPTION
## Resumo

- remove textos explicativos desnecessários que estavam poluindo a interface
- simplifica o painel `/admin` mantendo apenas o título do card e a navegação
- limpa `/admin/associados` com foco em consulta, filtros e ações mais objetivas
- substitui a visualização resumida por modal com dados completos do associado
- passa a exibir na modal todos os dados persistidos do associado, incluindo dependentes
- ajusta a grade de associados para caber sem scroll horizontal
- simplifica `/admin/permissoes` removendo o card de promoção de perfil existente
- melhora o texto de convites por email para linguagem leiga
- reorganiza a seção de dependentes da área do associado
- limpa textos auxiliares do bloco de foto
- atualiza a lista de categorias de associados
- adiciona migration para compatibilizar as novas categorias no Supabase

## Validação local

- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

## Ajustes principais

- `/admin`
  - remove hero textual excessivo e cards de direção
- `/admin/associados`
  - remove textos redundantes
  - remove card redundante de concessões por email
  - melhora grid e paginação visual
  - adiciona modal textual com dados completos do associado
- `/admin/permissoes`
  - remove card `Promover perfil existente`
  - mantém foco em acessos atuais e convites por email
- `/associado`
  - move `Adicionar dependente` para baixo da lista
  - remove texto extra no bloco de foto

## Observações

- esta branch foca só em limpeza visual, microcopy e simplificação de fluxos
- a migration de categorias precisa ser aplicada no Supabase para alinhar o banco com os novos valores

## Issues

- ajustes finos de interface e usabilidade
