### PR TITLE
Feat/publications area

### DIFF
--- a/docs/associate-enrollment-number-spec.md
+++ b/docs/associate-enrollment-number-spec.md
@@ -1,12 +1,12 @@
-# Especificação inicial da matrícula de associados
+# Especificação inicial da matrícula de associados e dependentes
 
 Issue de origem: [#21 Matrícula](https://github.com/thalescampelodac/landing-page-aajf/issues/21)
 
 ## Objetivo
 
-Definir como o sistema deve atribuir uma matrícula única para cada associado,
-de forma automática, consistente e sem depender de preenchimento manual pela
-administração.
+Definir como o sistema deve atribuir uma matrícula única para cada associado e
+para cada dependente, de forma automática, consistente e sem depender de
+preenchimento manual pela administração.
 
 ## Contexto atual
 
@@ -19,13 +19,17 @@ Hoje o sistema já possui:
 - área do associado
 - gestão administrativa de associados
 
-Mas ainda não existe um identificador de matrícula próprio da associação.
+Mas ainda não existe um identificador de matrícula próprio da associação para:
+
+- associados
+- dependentes
 
 ## Problema que a issue resolve
 
 Sem matrícula:
 
 - não existe um número único de referência do associado
+- não existe um número único de referência do dependente
 - a identificação visual da carteirinha fica incompleta
 - consultas administrativas ficam mais frágeis
 - futuras integrações financeiras, relatórios ou documentos ficam sem um
@@ -36,6 +40,7 @@ Sem matrícula:
 A matrícula deve ser:
 
 - única por associado
+- única por dependente
 - gerada automaticamente pelo sistema
 - imutável depois de criada
 - nunca reutilizada
@@ -46,25 +51,45 @@ A matrícula deve ser:
 
 ### Proposta principal
 
-Usar um número sequencial com zero à esquerda:
+Usar duas sequências independentes:
 
-- `000001`
-- `000002`
-- `000003`
+- associados: `000001`
+- dependentes: `D000001`
 
 ### Motivo
 
 Esse formato:
 
-- é simples para usuários leigos
-- funciona bem em carteirinhas
-- evita acoplar a matrícula ao ano, ao grupo ou ao tipo de associado
-- permite crescer sem precisar mudar a regra cedo
+- diferencia claramente associado de dependente
+- evita colisão visual entre cadastros de naturezas diferentes
+- continua simples para operação humana
+- mantém os dependentes identificáveis sem ambiguidade
+
+### Exemplos
+
+- associado: `000154`
+- dependente: `D000031`
+
+## Escopo da matrícula
+
+### Associado principal
+
+Cada associado principal recebe sua própria matrícula institucional.
+
+### Dependente
+
+Cada dependente também recebe sua própria matrícula institucional, separada da
+do associado principal.
+
+O dependente continua vinculado ao associado, mas não reaproveita nem compartilha
+o número do titular.
 
 ## Momento da atribuição
 
-A matrícula deve ser atribuída automaticamente na primeira criação do vínculo
-real do associado no sistema.
+A matrícula deve ser atribuída automaticamente:
+
+- para o associado, na primeira criação do vínculo real do associado no sistema
+- para o dependente, na primeira criação do dependente dentro da ficha do associado
 
 Na prática:
 
@@ -74,45 +99,64 @@ Na prática:
 3. essa matrícula passa a ficar gravada no cadastro do associado
 4. se o mesmo associado for editado, suspenso ou reativado depois, a matrícula
    permanece a mesma
+5. quando um dependente novo é criado, o sistema gera a próxima matrícula de
+   dependente disponível
+6. se o dependente for editado depois, a matrícula permanece a mesma
 
 ## Regra de unicidade
 
 - cada associado deve ter no máximo uma matrícula
-- uma matrícula nunca pode pertencer a dois associados
+- cada dependente deve ter no máximo uma matrícula
+- uma matrícula de associado nunca pode pertencer a dois associados
+- uma matrícula de dependente nunca pode pertencer a dois dependentes
 - uma matrícula já usada nunca deve voltar para a fila
 
 ## Onde armazenar
 
 ### Proposta
 
-Adicionar o campo na estrutura principal do associado, e não na conta de auth.
+Adicionar os campos na estrutura própria do cadastro institucional, e não na
+conta de auth.
 
-Campo sugerido:
+Campos sugeridos:
 
 - `aajf.associate_profiles.membership_number`
+- `aajf.associate_dependents.membership_number`
 
 ### Motivo
 
-A matrícula pertence ao cadastro institucional do associado, não ao mecanismo
-de login.
+A matrícula pertence ao cadastro institucional, não ao mecanismo de login.
 
 ## Regra de geração
 
 ### Algoritmo sugerido
 
-1. buscar a maior matrícula numérica já registrada
+#### Associados
+
+1. buscar a maior matrícula de associado já registrada
 2. incrementar em `+1`
 3. preencher com zero à esquerda até 6 dígitos
 4. salvar no mesmo fluxo da criação inicial do vínculo
 
-Exemplo:
+#### Dependentes
 
-- maior matrícula atual: `000154`
-- próxima matrícula gerada: `000155`
+1. buscar a maior matrícula de dependente já registrada
+2. incrementar em `+1`
+3. aplicar prefixo `D`
+4. preencher a parte numérica com zero à esquerda até 6 dígitos
+5. salvar no mesmo fluxo da criação do dependente
+
+Exemplos:
+
+- maior matrícula de associado atual: `000154`
+- próxima matrícula de associado: `000155`
+- maior matrícula de dependente atual: `D000031`
+- próxima matrícula de dependente: `D000032`
 
 ## Tratamento de concorrência
 
-Como a matrícula é sequencial, a geração precisa ser protegida contra colisão.
+Como a matrícula é sequencial, a geração precisa ser protegida contra colisão,
+tanto para associados quanto para dependentes.
 
 ### Recomendação técnica
 
@@ -134,8 +178,11 @@ prever backfill.
 Ao aplicar a feature:
 
 1. todos os associados já existentes recebem matrícula
-2. a ordem de atribuição deve seguir o vínculo mais antigo disponível
-3. se não houver data confiável suficiente, usar ordem estável por `created_at`
+2. todos os dependentes já existentes recebem matrícula
+3. a ordem de atribuição do associado deve seguir o vínculo mais antigo disponível
+4. a ordem de atribuição do dependente deve seguir `created_at` ou ordem estável
+   por `id`
+5. se não houver data confiável suficiente, usar ordem estável por `created_at`
    ou `id`
 
 ## Exibição no produto
@@ -146,6 +193,7 @@ A matrícula deve aparecer:
 
 - na listagem administrativa de associados
 - na modal de dados completos do associado
+- na visualização textual dos dependentes
 
 ### Área do associado
 
@@ -153,6 +201,7 @@ A matrícula deve aparecer:
 
 - na área do associado
 - na carteirinha digital
+- na listagem de dependentes, quando houver
 
 ## Regras de negócio
 
@@ -160,22 +209,24 @@ A matrícula deve aparecer:
 - matrícula não muda em reativação
 - matrícula continua associada ao cadastro mesmo com troca de email
 - matrícula deve existir para todo associado com vínculo válido no sistema
+- matrícula deve existir para todo dependente persistido no sistema
 - matrícula é obrigatória para exibição da carteirinha final
 
 ## Escopo sugerido da implementação
 
 ### Etapa 1
 
-- adicionar campo no banco
+- adicionar campos no banco
 - criar geração automática
-- criar constraint de unicidade
-- criar backfill dos associados já existentes
+- criar constraints de unicidade
+- criar backfill dos associados e dependentes já existentes
 
 ### Etapa 2
 
 - exibir matrícula no admin
 - exibir matrícula na área do associado
 - incluir matrícula na carteirinha
+- exibir matrícula de dependentes na visualização textual do admin
 
 ### Etapa 3
 
@@ -183,7 +234,7 @@ A matrícula deve aparecer:
 
 ## Perguntas em aberto
 
-1. A matrícula deve ter só número ou prefixo institucional, como `AAJF-000001`?
+1. O prefixo `D` para dependentes está ok ou a associação prefere outro formato?
 2. A associação quer reservar alguma faixa para migração manual futura?
 3. A matrícula deve aparecer também em filtros e busca do admin?
 
@@ -191,18 +242,24 @@ A matrícula deve aparecer:
 
 Minha recomendação para esta issue é:
 
-- formato: `000001`
+- associado: `000001`
+- dependente: `D000001`
 - geração: automática no backend
-- persistência: `aajf.associate_profiles.membership_number`
+- persistência:
+  - `aajf.associate_profiles.membership_number`
+  - `aajf.associate_dependents.membership_number`
 - regra: única, imutável e não reutilizável
-- backfill: obrigatório para os associados já existentes
+- backfill: obrigatório para associados e dependentes já existentes
 
 ## Critérios de aceite
 
 - todo novo associado recebe matrícula automaticamente
+- todo novo dependente recebe matrícula automaticamente
 - associados já existentes recebem matrícula por backfill
+- dependentes já existentes recebem matrícula por backfill
 - não existe colisão de matrícula
 - matrícula não é editável manualmente na interface
 - matrícula aparece no admin
 - matrícula aparece na área do associado
 - matrícula aparece na carteirinha digital
+- matrícula de dependente aparece na visualização administrativa dos dependentes

--- a/docs/associate-enrollment-number-spec.md
+++ b/docs/associate-enrollment-number-spec.md
@@ -1,0 +1,208 @@
+# Especificação inicial da matrícula de associados
+
+Issue de origem: [#21 Matrícula](https://github.com/thalescampelodac/landing-page-aajf/issues/21)
+
+## Objetivo
+
+Definir como o sistema deve atribuir uma matrícula única para cada associado,
+de forma automática, consistente e sem depender de preenchimento manual pela
+administração.
+
+## Contexto atual
+
+Hoje o sistema já possui:
+
+- autenticação por conta
+- concessão de vínculo de associado
+- ficha cadastral persistida
+- dependentes
+- área do associado
+- gestão administrativa de associados
+
+Mas ainda não existe um identificador de matrícula próprio da associação.
+
+## Problema que a issue resolve
+
+Sem matrícula:
+
+- não existe um número único de referência do associado
+- a identificação visual da carteirinha fica incompleta
+- consultas administrativas ficam mais frágeis
+- futuras integrações financeiras, relatórios ou documentos ficam sem um
+  identificador institucional estável
+
+## Direção proposta
+
+A matrícula deve ser:
+
+- única por associado
+- gerada automaticamente pelo sistema
+- imutável depois de criada
+- nunca reutilizada
+- independente do email da conta
+- preservada mesmo se o associado ficar `inactive` ou `suspended`
+
+## Formato da matrícula
+
+### Proposta principal
+
+Usar um número sequencial com zero à esquerda:
+
+- `000001`
+- `000002`
+- `000003`
+
+### Motivo
+
+Esse formato:
+
+- é simples para usuários leigos
+- funciona bem em carteirinhas
+- evita acoplar a matrícula ao ano, ao grupo ou ao tipo de associado
+- permite crescer sem precisar mudar a regra cedo
+
+## Momento da atribuição
+
+A matrícula deve ser atribuída automaticamente na primeira criação do vínculo
+real do associado no sistema.
+
+Na prática:
+
+1. a administração concede o vínculo do associado
+2. se aquele associado ainda não tiver matrícula, o sistema gera a próxima
+   matrícula disponível
+3. essa matrícula passa a ficar gravada no cadastro do associado
+4. se o mesmo associado for editado, suspenso ou reativado depois, a matrícula
+   permanece a mesma
+
+## Regra de unicidade
+
+- cada associado deve ter no máximo uma matrícula
+- uma matrícula nunca pode pertencer a dois associados
+- uma matrícula já usada nunca deve voltar para a fila
+
+## Onde armazenar
+
+### Proposta
+
+Adicionar o campo na estrutura principal do associado, e não na conta de auth.
+
+Campo sugerido:
+
+- `aajf.associate_profiles.membership_number`
+
+### Motivo
+
+A matrícula pertence ao cadastro institucional do associado, não ao mecanismo
+de login.
+
+## Regra de geração
+
+### Algoritmo sugerido
+
+1. buscar a maior matrícula numérica já registrada
+2. incrementar em `+1`
+3. preencher com zero à esquerda até 6 dígitos
+4. salvar no mesmo fluxo da criação inicial do vínculo
+
+Exemplo:
+
+- maior matrícula atual: `000154`
+- próxima matrícula gerada: `000155`
+
+## Tratamento de concorrência
+
+Como a matrícula é sequencial, a geração precisa ser protegida contra colisão.
+
+### Recomendação técnica
+
+Fazer a atribuição no banco, e não no cliente.
+
+O ideal é usar:
+
+- função SQL dedicada
+- ou sequence no Postgres
+- com constraint `unique`
+
+## Associados já existentes
+
+Como já existem associados no sistema antes da matrícula, a issue precisa
+prever backfill.
+
+### Regra sugerida
+
+Ao aplicar a feature:
+
+1. todos os associados já existentes recebem matrícula
+2. a ordem de atribuição deve seguir o vínculo mais antigo disponível
+3. se não houver data confiável suficiente, usar ordem estável por `created_at`
+   ou `id`
+
+## Exibição no produto
+
+### Administração
+
+A matrícula deve aparecer:
+
+- na listagem administrativa de associados
+- na modal de dados completos do associado
+
+### Área do associado
+
+A matrícula deve aparecer:
+
+- na área do associado
+- na carteirinha digital
+
+## Regras de negócio
+
+- matrícula não pode ser editada manualmente na interface
+- matrícula não muda em reativação
+- matrícula continua associada ao cadastro mesmo com troca de email
+- matrícula deve existir para todo associado com vínculo válido no sistema
+- matrícula é obrigatória para exibição da carteirinha final
+
+## Escopo sugerido da implementação
+
+### Etapa 1
+
+- adicionar campo no banco
+- criar geração automática
+- criar constraint de unicidade
+- criar backfill dos associados já existentes
+
+### Etapa 2
+
+- exibir matrícula no admin
+- exibir matrícula na área do associado
+- incluir matrícula na carteirinha
+
+### Etapa 3
+
+- preparar uso futuro em exportações, PDF e relatórios
+
+## Perguntas em aberto
+
+1. A matrícula deve ter só número ou prefixo institucional, como `AAJF-000001`?
+2. A associação quer reservar alguma faixa para migração manual futura?
+3. A matrícula deve aparecer também em filtros e busca do admin?
+
+## Recomendação final
+
+Minha recomendação para esta issue é:
+
+- formato: `000001`
+- geração: automática no backend
+- persistência: `aajf.associate_profiles.membership_number`
+- regra: única, imutável e não reutilizável
+- backfill: obrigatório para os associados já existentes
+
+## Critérios de aceite
+
+- todo novo associado recebe matrícula automaticamente
+- associados já existentes recebem matrícula por backfill
+- não existe colisão de matrícula
+- matrícula não é editável manualmente na interface
+- matrícula aparece no admin
+- matrícula aparece na área do associado
+- matrícula aparece na carteirinha digital

--- a/docs/publications-news-spec.md
+++ b/docs/publications-news-spec.md
@@ -1,0 +1,327 @@
+# Especificação inicial da área de publicações e notícias
+
+Issue de origem: [#24 Estruturar área de publicações e notícias](https://github.com/thalescampelodac/landing-page-aajf/issues/24)
+
+## Objetivo
+
+Definir como a área de publicações deve evoluir de uma lista estática para um
+módulo editorial real da landing page, com foco em notícias, destaques e
+conteúdo institucional.
+
+Esta issue deve organizar:
+
+- a experiência pública da página `/publicacoes`
+- a estrutura dos cards e da listagem na home
+- a modelagem futura dos dados editoriais
+- a base para gestão administrativa de notícias depois
+- o painel administrativo de criação, edição e publicação
+- o upload de imagem de capa
+
+## Situação atual
+
+Hoje o projeto já possui:
+
+- bloco de `Publicações` na home
+- página pública `/publicacoes`
+- cards visuais de publicação
+- conteúdo fixo vindo de `src/lib/site-content.ts`
+
+Isso atende bem como placeholder editorial, mas ainda não resolve:
+
+- criação de novas notícias pelo painel
+- edição e remoção de publicações
+- separação entre rascunho e publicado
+- organização por destaque, categoria ou data
+- leitura individual de notícia
+
+## Problema que a issue resolve
+
+Sem a `#14`, a área de publicações continua:
+
+- dependente de dados hardcoded
+- sem fluxo operacional para novas notícias
+- sem estrutura para crescimento de acervo
+- sem ponte com administração/editorial
+
+## Resultado esperado
+
+Ao final desta issue, a solução deve deixar claro:
+
+1. como uma notícia nasce no sistema;
+2. como ela aparece na home;
+3. como ela aparece na página `/publicacoes`;
+4. quais campos compõem uma publicação;
+5. como a administração vai publicar esse conteúdo futuramente.
+
+## Decomposição recomendada
+
+### 1. Modelagem e dados
+
+- criar tabela principal de publicações
+- definir campos editoriais
+- definir status editoriais
+- definir campo de destaque
+- preparar storage e imagem de capa
+
+### 2. Home conectada ao acervo real
+
+- substituir conteúdo hardcoded do bloco de publicações
+- renderizar destaque principal da home a partir do acervo publicado
+- renderizar publicações secundárias a partir do acervo publicado
+
+### 3. Página pública `/publicacoes`
+
+- listar publicações publicadas
+- manter hierarquia editorial e visual institucional
+- preparar espaço para paginação futura
+
+### 4. Página individual por slug
+
+- criar rota `/publicacoes/[slug]`
+- renderizar corpo completo da notícia
+- suportar compartilhamento e leitura longa
+
+### 5. Painel administrativo de publicações
+
+- criar área admin para listar publicações
+- criar fluxo de criação
+- criar fluxo de edição
+- permitir alternância entre `draft`, `published` e `archived`
+- permitir definir destaque
+
+### 6. Upload de imagem
+
+- permitir upload de capa da notícia
+- persistir imagem em storage
+- refletir imagem na home, na listagem e na página individual
+
+#### Regras da imagem de capa
+
+- formatos aceitos: `JPG`, `PNG`, `WEBP`
+- tamanho máximo: `5 MB`
+- orientação esperada: horizontal
+- proporção recomendada: `16:10`
+- resolução mínima recomendada: `1600x1000`
+- a imagem pode ficar ausente em `draft`
+- a imagem é obrigatória para `published`
+- o texto alternativo da imagem é obrigatório para `published`
+- o painel deve mostrar prévia antes do salvamento
+
+## Escopo funcional recomendado
+
+### 1. Home da landing
+
+O bloco de publicações da home deve continuar existindo como vitrine editorial.
+
+Função esperada:
+
+- destacar a publicação principal
+- listar outras publicações recentes
+- levar para `/publicacoes`
+
+Regra sugerida:
+
+- a home não deve mostrar tudo
+- ela deve mostrar apenas recorte editorial
+- algo como:
+  - 1 destaque principal
+  - 2 ou 3 publicações secundárias
+
+### 2. Página `/publicacoes`
+
+Esta página deve funcionar como listagem pública de notícias.
+
+Função esperada:
+
+- mostrar as publicações em ordem editorial
+- permitir leitura agradável do conjunto
+- servir como acervo inicial da associação
+
+Decisão recomendada:
+
+- manter uma listagem em cards ou blocos grandes
+- deixar espaço para futura paginação
+- não transformar a página em mural administrativo
+
+### 3. Página individual da notícia
+
+É recomendável que a notícia tenha URL própria.
+
+Exemplo:
+
+- `/publicacoes/[slug]`
+
+Vantagens:
+
+- leitura limpa
+- compartilhamento por link direto
+- base melhor para SEO
+- espaço para texto longo, galeria e anexos
+
+Minha recomendação:
+
+- esta issue já deve prever isso na estrutura
+- mesmo que a primeira entrega ainda comece pela listagem
+
+## Modelo editorial sugerido
+
+Cada publicação deve ter, no mínimo:
+
+- `id`
+- `slug`
+- `title`
+- `excerpt`
+- `body`
+- `cover_image_url`
+- `cover_image_alt`
+- `published_at`
+- `featured`
+- `status`
+- `author_name`
+- `created_at`
+- `updated_at`
+
+### Campos opcionais recomendados
+
+- `category`
+- `seo_title`
+- `seo_description`
+- `gallery`
+- `external_link`
+
+## Status editoriais sugeridos
+
+Sugestão inicial:
+
+- `draft`
+- `published`
+- `archived`
+
+Objetivo:
+
+- permitir criação sem publicação imediata
+- evitar que tudo entre no ar automaticamente
+- dar margem para revisão editorial
+
+## Destaque editorial
+
+É importante existir uma noção de destaque.
+
+Sugestão:
+
+- apenas uma notícia pode ser o `featured` principal da home
+- na listagem de `/publicacoes`, ela também pode aparecer primeiro
+
+Pergunta em aberto:
+
+- o destaque será manual?
+- ou sempre a publicação mais recente publicada?
+
+Minha recomendação:
+
+- destaque manual
+
+## Estrutura de dados sugerida
+
+### Tabela principal
+
+`aajf.publications`
+
+Campos sugeridos:
+
+- `id`
+- `slug`
+- `title`
+- `excerpt`
+- `body`
+- `cover_image_url`
+- `status`
+- `featured`
+- `category`
+- `published_at`
+- `author_name`
+- `seo_title`
+- `seo_description`
+- `created_at`
+- `updated_at`
+
+### Possível tabela de mídia futura
+
+Se a associação quiser múltiplas imagens por notícia depois:
+
+`aajf.publication_assets`
+
+Campos sugeridos:
+
+- `id`
+- `publication_id`
+- `asset_url`
+- `asset_type`
+- `caption`
+- `sort_order`
+- `created_at`
+
+## Relação com a área administrativa
+
+Esta issue não precisa fechar toda a UX de administração agora, mas precisa
+deixar a direção pronta.
+
+Futuro esperado:
+
+- painel administrativo cria publicação
+- painel salva rascunho
+- painel publica
+- painel edita ou arquiva
+
+Então a modelagem desta issue deve nascer compatível com isso.
+
+## Regras de negócio sugeridas
+
+- publicações públicas não dependem de login
+- apenas administração autorizada pode criar/editar/publicar
+- notícia arquivada não aparece na home
+- notícia `draft` não aparece publicamente
+- a home mostra só recorte do acervo
+- `/publicacoes` mostra o acervo publicado
+- imagem de capa e texto alternativo são obrigatórios para `published`
+
+## Direção visual
+
+A área de publicações deve continuar institucional e editorial, não parecer
+blog genérico ou painel de sistema.
+
+Direção recomendada:
+
+- cards amplos
+- boa hierarquia entre imagem, título e data
+- destaque claro para notícia principal
+- leitura confortável para texto longo
+
+## Perguntas em aberto
+
+1. A primeira entrega já terá página individual por `slug`?
+2. A administração de notícias entra nesta mesma issue ou em issue separada?
+3. Vamos ter categorias editoriais ou só notícias em lista simples?
+4. As publicações poderão ter mais de uma imagem?
+5. O corpo será texto simples, markdown, rich text ou blocos?
+
+## Critérios de aceite propostos
+
+- a estrutura da área de publicações deixa de depender de conteúdo hardcoded como solução final
+- a modelagem de notícia fica definida
+- a página `/publicacoes` fica preparada para crescer como acervo
+- existe direção clara para destaque editorial na home
+- existe página individual por `slug`
+- existe base administrativa para criar, editar e publicar
+- a solução fica compatível com futura gestão administrativa de notícias
+
+## Fora de escopo por enquanto
+
+Este documento ainda não fecha:
+
+- tradução multilíngue das notícias
+- SEO completo por idioma
+- comentários
+- compartilhamento social avançado
+- analytics editorial
+- workflow de aprovação com múltiplos revisores

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,20 @@
 import type { NextConfig } from "next";
 
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseHostname = supabaseUrl ? new URL(supabaseUrl).hostname : null;
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: supabaseHostname
+      ? [
+          {
+            protocol: "https",
+            hostname: supabaseHostname,
+            pathname: "/storage/v1/object/public/**",
+          },
+        ]
+      : [],
+  },
 };
 
 export default nextConfig;

--- a/src/app/access-routes.test.tsx
+++ b/src/app/access-routes.test.tsx
@@ -29,6 +29,7 @@ vi.mock("@/lib/supabase/associate-profile", async () => {
         dependents: [],
         email: "associado@example.com",
         fullName: "Associado de Exemplo",
+        membershipNumber: "000001",
         nationality: "Brasileira",
         observation: "Observação de teste",
         phone: "(32) 99999-0000",

--- a/src/app/admin/comunicados/actions.ts
+++ b/src/app/admin/comunicados/actions.ts
@@ -1,0 +1,312 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createAdminClient } from "@/lib/supabase/admin-client";
+import { getAdminAccess } from "@/lib/supabase/access";
+import type { PublicationStatus } from "@/lib/supabase/publications";
+import {
+  publicationCoverAcceptedMimeTypes,
+  publicationCoverBucketName,
+  publicationCoverMaxFileSizeInBytes,
+} from "@/lib/supabase/publication-shared";
+import { createClient } from "@/lib/supabase/server";
+
+export type AdminPublicationsActionState = {
+  error?: string;
+  success?: string;
+};
+
+export async function savePublication(
+  _previousState: AdminPublicationsActionState,
+  formData: FormData,
+): Promise<AdminPublicationsActionState> {
+  const access = await getAdminAccess();
+
+  if (access.status !== "authorized") {
+    return { error: "Apenas administradores ativos podem operar publicações." };
+  }
+
+  const id = String(formData.get("id") || "").trim();
+  const title = String(formData.get("title") || "").trim();
+  const slugInput = String(formData.get("slug") || "").trim();
+  const excerpt = String(formData.get("excerpt") || "").trim();
+  const body = String(formData.get("body") || "").trim();
+  const coverImageAlt = String(formData.get("coverImageAlt") || "").trim();
+  const category = String(formData.get("category") || "").trim();
+  const authorName = String(formData.get("authorName") || "").trim();
+  const status = String(formData.get("status") || "").trim();
+  const seoTitle = String(formData.get("seoTitle") || "").trim();
+  const seoDescription = String(formData.get("seoDescription") || "").trim();
+  const publishedAtInput = String(formData.get("publishedAt") || "").trim();
+  const featured = formData.get("featured") === "on";
+  const coverImageFileEntry = formData.get("coverImageFile");
+  const coverImageFile =
+    coverImageFileEntry instanceof File && coverImageFileEntry.size > 0
+      ? coverImageFileEntry
+      : null;
+
+  if (!title) {
+    return { error: "Informe o título da publicação." };
+  }
+
+  if (!excerpt) {
+    return { error: "Informe o resumo da publicação." };
+  }
+
+  if (!body) {
+    return { error: "Informe o corpo da publicação." };
+  }
+
+  if (!isValidPublicationStatus(status)) {
+    return { error: "Selecione um status válido para a publicação." };
+  }
+
+  if (
+    coverImageFile &&
+    !(publicationCoverAcceptedMimeTypes as readonly string[]).includes(
+      coverImageFile.type,
+    )
+  ) {
+    return { error: "Use uma imagem JPG, PNG ou WEBP para a capa da publicação." };
+  }
+
+  if (coverImageFile && coverImageFile.size > publicationCoverMaxFileSizeInBytes) {
+    return { error: "A imagem de capa deve ter no máximo 5 MB." };
+  }
+
+  const baseSlug = slugify(slugInput || title);
+
+  if (!baseSlug) {
+    return { error: "Não foi possível gerar um slug válido para a publicação." };
+  }
+
+  const publishedAt =
+    status === "published"
+      ? normalizePublishedAt(publishedAtInput) ?? new Date().toISOString()
+      : normalizePublishedAt(publishedAtInput);
+
+  const supabase = await createClient();
+  const slug = await resolveUniqueSlug(supabase, baseSlug, id || null);
+  const slugWasAdjusted = slug !== baseSlug;
+  const publicationId = id || crypto.randomUUID();
+  const { data: existingPublication, error: existingPublicationError } = await supabase
+    .schema("aajf")
+    .from("publications")
+    .select("cover_image_url")
+    .eq("id", publicationId)
+    .maybeSingle();
+
+  if (existingPublicationError) {
+    return { error: existingPublicationError.message };
+  }
+
+  let nextCoverImagePath = existingPublication?.cover_image_url?.trim() || null;
+
+  if (coverImageFile) {
+    try {
+      const adminSupabase = createAdminClient();
+      const extension = resolvePublicationImageExtension(coverImageFile);
+      const uploadedCoverPath = `publications/${publicationId}/cover-${Date.now()}.${extension}`;
+      const previousCoverPath = existingPublication?.cover_image_url?.trim() || null;
+
+      const { error: uploadError } = await adminSupabase.storage
+        .from(publicationCoverBucketName)
+        .upload(uploadedCoverPath, coverImageFile, {
+          cacheControl: "3600",
+          contentType: coverImageFile.type,
+          upsert: true,
+        });
+
+      if (uploadError) {
+        return { error: uploadError.message };
+      }
+
+      if (
+        previousCoverPath &&
+        previousCoverPath !== uploadedCoverPath &&
+        !/^https?:\/\//i.test(previousCoverPath)
+      ) {
+        const { error: removePreviousCoverError } = await adminSupabase.storage
+          .from(publicationCoverBucketName)
+          .remove([previousCoverPath]);
+
+        if (removePreviousCoverError) {
+          return { error: removePreviousCoverError.message };
+        }
+      }
+
+      nextCoverImagePath = uploadedCoverPath;
+    } catch {
+      return {
+        error:
+          "O upload da capa ainda não está disponível neste ambiente. Verifique a configuração do Storage do Supabase.",
+      };
+    }
+  }
+
+  if (status === "published" && !nextCoverImagePath) {
+    return { error: "Publicações publicadas precisam ter uma imagem de capa." };
+  }
+
+  if (status === "published" && !coverImageAlt) {
+    return {
+      error:
+        "Publicações publicadas precisam ter um texto alternativo para a imagem de capa.",
+    };
+  }
+
+  if (featured) {
+    const { error: clearFeaturedError } = await supabase
+      .schema("aajf")
+      .from("publications")
+      .update({ featured: false })
+      .neq("id", id || "00000000-0000-0000-0000-000000000000");
+
+    if (clearFeaturedError) {
+      return { error: clearFeaturedError.message };
+    }
+  }
+
+  const payload = {
+    author_name: authorName || null,
+    body,
+    category: category || null,
+    cover_image_alt: coverImageAlt || null,
+    cover_image_url: nextCoverImagePath,
+    excerpt,
+    featured,
+    published_at: publishedAt,
+    seo_description: seoDescription || null,
+    seo_title: seoTitle || null,
+    slug,
+    status,
+    title,
+  };
+
+  if (id) {
+    const { error } = await supabase
+      .schema("aajf")
+      .from("publications")
+      .update(payload)
+      .eq("id", id);
+
+    if (error) {
+      return { error: error.message };
+    }
+  } else {
+    const { error } = await supabase
+      .schema("aajf")
+      .from("publications")
+      .insert({ ...payload, id: publicationId });
+
+    if (error) {
+      return { error: error.message };
+    }
+  }
+
+  revalidatePath("/");
+  revalidatePath("/publicacoes");
+  revalidatePath(`/publicacoes/${slug}`);
+  revalidatePath("/admin/comunicados");
+
+  return {
+    success: buildSuccessMessage({
+      isUpdate: Boolean(id),
+      slug,
+      slugWasAdjusted,
+    }),
+  };
+}
+
+function isValidPublicationStatus(status: string): status is PublicationStatus {
+  return status === "draft" || status === "published" || status === "archived";
+}
+
+function normalizePublishedAt(value: string) {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
+}
+
+function slugify(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function resolvePublicationImageExtension(file: File) {
+  if (file.type === "image/png") {
+    return "png";
+  }
+
+  if (file.type === "image/webp") {
+    return "webp";
+  }
+
+  return "jpg";
+}
+
+async function resolveUniqueSlug(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  baseSlug: string,
+  currentId: string | null,
+) {
+  const { data, error } = await supabase
+    .schema("aajf")
+    .from("publications")
+    .select("id, slug")
+    .ilike("slug", `${baseSlug}%`);
+
+  if (error || !data?.length) {
+    return baseSlug;
+  }
+
+  const conflictingSlugs = new Set(
+    data
+      .filter((publication) => publication.id !== currentId)
+      .map((publication) => publication.slug),
+  );
+
+  if (!conflictingSlugs.has(baseSlug)) {
+    return baseSlug;
+  }
+
+  let index = 2;
+
+  while (conflictingSlugs.has(`${baseSlug}-${index}`)) {
+    index += 1;
+  }
+
+  return `${baseSlug}-${index}`;
+}
+
+function buildSuccessMessage({
+  isUpdate,
+  slug,
+  slugWasAdjusted,
+}: {
+  isUpdate: boolean;
+  slug: string;
+  slugWasAdjusted: boolean;
+}) {
+  const baseMessage = isUpdate
+    ? "Publicação atualizada com sucesso."
+    : "Publicação criada com sucesso.";
+
+  if (!slugWasAdjusted) {
+    return baseMessage;
+  }
+
+  return `${baseMessage} O link final ficou como /publicacoes/${slug}.`;
+}

--- a/src/app/admin/comunicados/page.test.tsx
+++ b/src/app/admin/comunicados/page.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import AdminComunicadosPage from "@/app/admin/comunicados/page";
+
+const { getAdminPublicationsDataMock, redirectMock } = vi.hoisted(() => ({
+  getAdminPublicationsDataMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock("@/lib/supabase/admin-publications", () => ({
+  getAdminPublicationsData: getAdminPublicationsDataMock,
+}));
+
+vi.mock("@/components/admin-publications-manager", () => ({
+  AdminPublicationsManager: ({
+    publications,
+  }: {
+    publications: Array<{ title: string }>;
+  }) => (
+    <div>
+      <p>Manager mock</p>
+      {publications.map((publication) => (
+        <span key={publication.title}>{publication.title}</span>
+      ))}
+    </div>
+  ),
+}));
+
+describe("AdminComunicadosPage", () => {
+  beforeEach(() => {
+    redirectMock.mockClear();
+    getAdminPublicationsDataMock.mockReset();
+  });
+
+  it("redireciona usuario sem sessao para o login administrativo", async () => {
+    getAdminPublicationsDataMock.mockResolvedValue({
+      access: { status: "unauthenticated" },
+    });
+
+    await AdminComunicadosPage();
+
+    expect(redirectMock).toHaveBeenCalledWith("/entrar?next=/admin/comunicados");
+  });
+
+  it("renderiza modulo de publicacoes para admin autorizado", async () => {
+    getAdminPublicationsDataMock.mockResolvedValue({
+      access: {
+        email: "admin@example.com",
+        profileId: "profile-admin",
+        role: "super_admin",
+        status: "authorized",
+      },
+      publications: [
+        {
+          authorName: "Equipe AAJF",
+          body: "Corpo da notícia",
+          category: "Eventos",
+          coverImageAlt: "Capa da notícia",
+          coverImagePath: "publications/cover.png",
+          coverImageUrl: "https://example.com/cover.png",
+          createdAt: "2026-05-05T10:00:00.000Z",
+          excerpt: "Resumo curto",
+          featured: true,
+          id: "publication-1",
+          publishedAt: "2026-05-05T10:00:00.000Z",
+          seoDescription: "SEO description",
+          seoTitle: "SEO title",
+          slug: "festa-de-maio",
+          status: "published",
+          title: "Festa de Maio",
+          updatedAt: "2026-05-05T12:00:00.000Z",
+        },
+      ],
+    });
+
+    render(await AdminComunicadosPage());
+
+    expect(
+      screen.getByRole("heading", {
+        name: /Publicações e notícias/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Manager mock/i)).toBeInTheDocument();
+    expect(screen.getByText(/Festa de Maio/i)).toBeInTheDocument();
+  });
+
+  it("renderiza fallback amigavel quando o acervo falha ao carregar", async () => {
+    getAdminPublicationsDataMock.mockRejectedValue(
+      new Error("permission denied for table publications"),
+    );
+
+    render(await AdminComunicadosPage());
+
+    expect(
+      screen.getByRole("heading", {
+        name: /O módulo ainda não conseguiu acessar o acervo editorial/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/permission denied for table publications/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/comunicados/page.tsx
+++ b/src/app/admin/comunicados/page.tsx
@@ -1,31 +1,87 @@
 import { redirect } from "next/navigation";
 import { AdminAccessPanel } from "@/components/admin-access-panel";
-import { getAdminAccess } from "@/lib/supabase/access";
+import { AdminPublicationsManager } from "@/components/admin-publications-manager";
+import {
+  getAdminPublicationsData,
+  type AdminPublicationsData,
+} from "@/lib/supabase/admin-publications";
 
 export default async function AdminComunicadosPage() {
-  const access = await getAdminAccess();
+  const result = await loadAdminPublicationsResult();
+
+  if ("error" in result) {
+    return <AdminPublicationsLoadError error={result.error} />;
+  }
+
+  const { data } = result;
+  const { access } = data;
 
   if (access.status === "unauthenticated") {
     redirect("/entrar?next=/admin/comunicados");
   }
 
+  const authorizedData = isAuthorizedAdminPublicationsData(data) ? data : null;
+
   return (
     <AdminAccessPanel
       access={access}
-      authorizedDescription="Este módulo organiza o espaço futuro para avisos internos, publicações administrativas e comunicação com associados."
-      authorizedTitle="Comunicados e publicações internas"
+      authorizedDescription=""
+      authorizedTitle="Publicações e notícias"
     >
-      <div className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
-        <p className="section-eyebrow">Módulo futuro</p>
-        <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
-          Um espaço para operar a comunicação da associação
-        </h3>
-        <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--color-green-deep)]">
-          Aqui vamos concentrar os fluxos futuros de comunicados, avisos e
-          publicações que precisarem de uma camada administrativa antes de
-          chegarem às áreas públicas ou restritas.
+      {authorizedData ? (
+        <AdminPublicationsManager publications={authorizedData.publications} />
+      ) : null}
+    </AdminAccessPanel>
+  );
+}
+
+function isAuthorizedAdminPublicationsData(
+  data: AdminPublicationsData,
+): data is Extract<AdminPublicationsData, { access: { status: "authorized" } }> {
+  return data.access.status === "authorized";
+}
+
+function getErrorMessage(error: unknown) {
+  if (error && typeof error === "object" && "message" in error) {
+    return String(error.message);
+  }
+
+  return "Não foi possível carregar os dados administrativos das publicações.";
+}
+
+async function loadAdminPublicationsResult() {
+  try {
+    const data = await getAdminPublicationsData();
+    return { data } as const;
+  } catch (error) {
+    return { error } as const;
+  }
+}
+
+function AdminPublicationsLoadError({ error }: { error: unknown }) {
+  return (
+    <section className="soft-card rounded-[2rem] p-8 sm:p-10 lg:p-12">
+      <p className="section-eyebrow">Publicações e notícias</p>
+      <h1 className="section-title mt-4 max-w-3xl">
+        O módulo ainda não conseguiu acessar o acervo editorial.
+      </h1>
+      <p className="section-description mt-6 max-w-2xl">
+        Isso costuma acontecer quando a migration da tabela de publicações ainda
+        não foi aplicada no Supabase, ou quando as permissões dessa tabela ainda
+        não entraram em vigor no ambiente atual.
+      </p>
+
+      <div className="mt-8 rounded-[1.5rem] border border-[rgba(154,31,43,0.12)] bg-[rgba(255,250,243,0.74)] p-5">
+        <p className="text-sm font-medium text-[var(--color-red-deep)]">
+          {getErrorMessage(error)}
+        </p>
+        <p className="mt-3 text-sm leading-7 text-[var(--color-green-deep)]">
+          Verifique principalmente a migration
+          `20260504164000_create_publications.sql`, que cria `aajf.publications`
+          com RLS, policies administrativas e grants para `anon` e
+          `authenticated`.
         </p>
       </div>
-    </AdminAccessPanel>
+    </section>
   );
 }

--- a/src/app/associado/actions.ts
+++ b/src/app/associado/actions.ts
@@ -321,22 +321,40 @@ export async function saveAssociateProfile(
     return { error: baseProfileUpdateError.message };
   }
 
-  const { error: deleteDependentsError } = await supabase
+  const { data: existingDependents, error: existingDependentsError } = await supabase
     .schema("aajf")
     .from("associate_dependents")
-    .delete()
+    .select("id")
     .eq("associate_profile_id", profileRecord.id);
 
-  if (deleteDependentsError) {
-    return { error: deleteDependentsError.message };
+  if (existingDependentsError) {
+    return { error: existingDependentsError.message };
+  }
+
+  const submittedDependentIds = new Set(dependents.map((dependent) => dependent.id));
+  const dependentIdsToDelete = (existingDependents ?? [])
+    .map((dependent) => dependent.id)
+    .filter((dependentId) => !submittedDependentIds.has(dependentId));
+
+  if (dependentIdsToDelete.length) {
+    const { error: deleteDependentsError } = await supabase
+      .schema("aajf")
+      .from("associate_dependents")
+      .delete()
+      .in("id", dependentIdsToDelete);
+
+    if (deleteDependentsError) {
+      return { error: deleteDependentsError.message };
+    }
   }
 
   if (dependents.length) {
-    const { error: insertDependentsError } = await supabase
+    const { error: upsertDependentsError } = await supabase
       .schema("aajf")
       .from("associate_dependents")
-      .insert(
+      .upsert(
         dependents.map((dependent) => ({
+          id: dependent.id,
           associate_profile_id: profileRecord.id,
           birth_date: dependent.birthDate || null,
           category: dependent.category || null,
@@ -345,10 +363,11 @@ export async function saveAssociateProfile(
           nationality: dependent.nationality || null,
           rg: dependent.rg || null,
         })),
+        { onConflict: "id" },
       );
 
-    if (insertDependentsError) {
-      return { error: insertDependentsError.message };
+    if (upsertDependentsError) {
+      return { error: upsertDependentsError.message };
     }
   }
 

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,9 +1,49 @@
 import { render, screen } from "@testing-library/react";
 import Home from "@/app/page";
 
+vi.mock("@/lib/supabase/publications", () => ({
+  formatPublicationDate: vi.fn(() => "18 de janeiro de 2023"),
+  getPublishedPublications: vi.fn(async () => [
+    {
+      authorName: "Associação Alemã de Juiz de Fora",
+      body: ["Texto de teste"],
+      category: null,
+      coverImageUrl: "/images/publicacoes/1/162257-jpg.webp",
+      createdAt: null,
+      excerpt: "Resumo de teste",
+      featured: true,
+      id: "seed-1",
+      publishedAt: "2023-01-18T00:00:00.000Z",
+      seoDescription: null,
+      seoTitle: null,
+      slug: "tradicao-em-movimento",
+      status: "published",
+      title: "Grupo Schmetterling",
+      updatedAt: null,
+    },
+    {
+      authorName: "Associação Alemã de Juiz de Fora",
+      body: ["Texto secundário"],
+      category: null,
+      coverImageUrl: null,
+      createdAt: null,
+      excerpt: "Outro resumo",
+      featured: false,
+      id: "seed-2",
+      publishedAt: "2023-01-18T00:00:00.000Z",
+      seoDescription: null,
+      seoTitle: null,
+      slug: "outra-publicacao",
+      status: "published",
+      title: "Outra publicação",
+      updatedAt: null,
+    },
+  ]),
+}));
+
 describe("Home page", () => {
-  it("renderiza os principais blocos da landing", () => {
-    render(<Home />);
+  it("renderiza os principais blocos da landing", async () => {
+    render(await Home());
 
     expect(
       screen.getByRole("heading", {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,8 @@
 import { HomeContent } from "@/components/home-content";
+import { getPublishedPublications } from "@/lib/supabase/publications";
 
-export default function Home() {
-  return <HomeContent />;
+export default async function Home() {
+  const posts = await getPublishedPublications();
+
+  return <HomeContent posts={posts} />;
 }

--- a/src/app/publicacoes/[slug]/page.tsx
+++ b/src/app/publicacoes/[slug]/page.tsx
@@ -1,0 +1,67 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import {
+  formatPublicationDate,
+  getPublicationBySlug,
+  getPublishedPublications,
+} from "@/lib/supabase/publications";
+
+export async function generateStaticParams() {
+  const publications = await getPublishedPublications();
+
+  return publications.map((publication) => ({
+    slug: publication.slug,
+  }));
+}
+
+export default async function PublicacaoDetalhePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  if (!slug) {
+    notFound();
+  }
+
+  const publication = await getPublicationBySlug(slug);
+
+  return (
+    <main className="section-shell mt-8 flex-1 pb-16">
+      <article className="soft-card overflow-hidden rounded-[2rem]">
+        <div className="relative min-h-[280px] bg-[linear-gradient(135deg,#20452e_0%,#8b1e28_45%,#d6b06a_100%)]">
+          {publication.coverImageUrl ? (
+            <Image
+              src={publication.coverImageUrl}
+              alt={publication.coverImageAlt || publication.title}
+              fill
+              className="object-cover"
+              priority
+            />
+          ) : null}
+        </div>
+
+        <div className="p-8 sm:p-10">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--color-red)]">
+            {publication.featured ? "Publicação em destaque" : "Publicação"}
+          </p>
+          <h1 className="mt-4 font-heading text-4xl leading-tight text-[var(--color-ink)] sm:text-5xl">
+            {publication.title}
+          </h1>
+          <div className="mt-6 flex flex-wrap items-center gap-4 text-xs font-semibold uppercase tracking-[0.22em] text-[var(--color-muted-strong)]">
+            <span>{formatPublicationDate(publication.publishedAt)}</span>
+            {publication.authorName ? <span>{publication.authorName}</span> : null}
+            {publication.category ? <span>{publication.category}</span> : null}
+          </div>
+
+          <div className="mt-8 grid gap-5 text-base leading-8 text-[var(--color-muted)]">
+            {publication.body.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/src/app/publicacoes/page.tsx
+++ b/src/app/publicacoes/page.tsx
@@ -1,8 +1,13 @@
 import Image from "next/image";
 import { SectionTitle } from "@/components/section-title";
-import { posts } from "@/lib/site-content";
+import {
+  formatPublicationDate,
+  getPublishedPublications,
+} from "@/lib/supabase/publications";
 
-export default function PublicacoesPage() {
+export default async function PublicacoesPage() {
+  const posts = await getPublishedPublications();
+
   return (
     <main className="section-shell mt-8 flex-1 pb-16">
       <section className="soft-card rounded-[2rem] p-8 sm:p-10">
@@ -20,10 +25,10 @@ export default function PublicacoesPage() {
             className="soft-card overflow-hidden rounded-[2rem] lg:grid lg:grid-cols-[0.95fr_1.05fr]"
           >
             <div className="relative min-h-[260px] bg-[linear-gradient(135deg,#20452e_0%,#8b1e28_45%,#d6b06a_100%)]">
-              {post.image ? (
+              {post.coverImageUrl ? (
                 <Image
-                  src={post.image}
-                  alt={post.title}
+                  src={post.coverImageUrl}
+                  alt={post.coverImageAlt || post.title}
                   fill
                   className="object-cover"
                   priority={index === 0}
@@ -39,7 +44,7 @@ export default function PublicacoesPage() {
                 {post.title}
               </h2>
               <p className="mt-5 text-xs font-semibold uppercase tracking-[0.24em] text-[var(--color-muted-strong)]">
-                {post.date}
+                {formatPublicationDate(post.publishedAt)}
               </p>
               <div className="mt-6 grid gap-4 text-base leading-8 text-[var(--color-muted)]">
                 {post.body.map((paragraph) => (

--- a/src/components/admin-associates-manager.tsx
+++ b/src/components/admin-associates-manager.tsx
@@ -34,7 +34,10 @@ export function AdminAssociatesManager({
     const matchesQuery =
       !normalizedQuery ||
       membership.profile.email.toLowerCase().includes(normalizedQuery) ||
-      (membership.profile.fullName || "").toLowerCase().includes(normalizedQuery);
+      (membership.profile.fullName || "").toLowerCase().includes(normalizedQuery) ||
+      (membership.profileSnapshot?.membershipNumber || "")
+        .toLowerCase()
+        .includes(normalizedQuery);
 
     const matchesStatus =
       statusFilter === "all" || membership.status === statusFilter;
@@ -60,7 +63,7 @@ export function AdminAssociatesManager({
           <div className="mt-4 grid gap-4">
             <div className="grid gap-4 rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,250,243,0.72)] p-4 lg:grid-cols-3">
               <label className="form-field">
-                <span>Buscar por nome ou email</span>
+                <span>Buscar por nome, email ou matrícula</span>
                 <input
                   onChange={(event) => {
                     setQuery(event.target.value);
@@ -242,8 +245,11 @@ function AssociateMembershipRow({
 
         <div className="grid gap-4 lg:grid-cols-[minmax(11rem,1.3fr)_minmax(12rem,1.25fr)_minmax(7rem,0.8fr)_minmax(8rem,0.9fr)_minmax(9rem,0.9fr)_minmax(8.5rem,0.95fr)] lg:items-start">
           <div className="min-w-0">
-            <p className="text-[1.05rem] font-semibold leading-7 text-[var(--color-green-deep)]">
+              <p className="text-[1.05rem] font-semibold leading-7 text-[var(--color-green-deep)]">
               {membership.profile.fullName || "Sem nome informado"}
+            </p>
+            <p className="mt-1 text-sm font-medium text-[var(--color-muted)]">
+              Matrícula: {membership.profileSnapshot?.membershipNumber || "Pendente"}
             </p>
             <p className="mt-2 text-[0.7rem] uppercase tracking-[0.16em] text-[var(--color-red)]">
               Concedido em {formatDateTime(membership.grantedAt)}
@@ -321,6 +327,7 @@ function AssociateMembershipRow({
               <div className="grid gap-6 text-sm leading-7 text-[var(--color-green-deep)]">
                 <div className="grid gap-2">
                   <p><strong>Email:</strong> {membership.profile.email}</p>
+                  <p><strong>Matrícula do associado:</strong> {membership.profileSnapshot?.membershipNumber || "Pendente"}</p>
                   <p><strong>Status do vínculo:</strong> {membership.status}</p>
                   <p><strong>Concedido em:</strong> {formatDateTime(membership.grantedAt)}</p>
                   <p><strong>Observações administrativas:</strong> {membership.notes || "Nenhuma observação registrada."}</p>
@@ -366,6 +373,7 @@ function AssociateMembershipRow({
                         >
                           <div className="space-y-2">
                             <p><strong>Dependente {index + 1}:</strong> {dependent.fullName}</p>
+                            <p><strong>Matrícula:</strong> {dependent.membershipNumber || "Pendente"}</p>
                             <p><strong>Categoria:</strong> {dependent.category || "Não definida"}</p>
                             <p><strong>CPF:</strong> {dependent.cpf || "Não informado"}</p>
                             <p><strong>RG:</strong> {dependent.rg || "Não informado"}</p>

--- a/src/components/admin-publications-manager.tsx
+++ b/src/components/admin-publications-manager.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import { useActionState, useMemo, useState, type ChangeEvent } from "react";
+import {
+  savePublication,
+  type AdminPublicationsActionState,
+} from "@/app/admin/comunicados/actions";
+import type { AdminPublicationRecord } from "@/lib/supabase/admin-publications";
+import {
+  publicationCoverAcceptedMimeTypes,
+  publicationCoverMaxFileSizeInBytes,
+  publicationCoverMinimumHeight,
+  publicationCoverMinimumWidth,
+  publicationCoverRecommendedRatio,
+} from "@/lib/supabase/publication-shared";
+
+const initialState: AdminPublicationsActionState = {};
+
+type AdminPublicationsManagerProps = {
+  publications: AdminPublicationRecord[];
+};
+
+export function AdminPublicationsManager({
+  publications,
+}: AdminPublicationsManagerProps) {
+  const [state, action, isPending] = useActionState(savePublication, initialState);
+  const [selectedPublicationId, setSelectedPublicationId] = useState<string | null>(
+    publications[0]?.id ?? null,
+  );
+  const selectedPublication =
+    publications.find((publication) => publication.id === selectedPublicationId) ?? null;
+
+  const formKey = selectedPublication?.id ?? "new-publication";
+
+  const publicationCounts = useMemo(
+    () => ({
+      archived: publications.filter((publication) => publication.status === "archived")
+        .length,
+      drafts: publications.filter((publication) => publication.status === "draft").length,
+      published: publications.filter(
+        (publication) => publication.status === "published",
+      ).length,
+    }),
+    [publications],
+  );
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,1.02fr)_minmax(21rem,0.98fr)]">
+      <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="section-eyebrow">Acervo editorial</p>
+            <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
+              Publicações registradas
+            </h3>
+            <p className="mt-3 text-sm leading-7 text-[var(--color-muted)]">
+              Clique em uma publicação da lista para carregar os dados no editor.
+            </p>
+          </div>
+          <button
+            className="secondary-button"
+            onClick={() => setSelectedPublicationId(null)}
+            type="button"
+          >
+            Nova publicação
+          </button>
+        </div>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <StatCard label="Rascunhos" value={publicationCounts.drafts} />
+          <StatCard label="Publicadas" value={publicationCounts.published} />
+          <StatCard label="Arquivadas" value={publicationCounts.archived} />
+        </div>
+
+        <div className="mt-6 grid gap-4">
+          {publications.length ? (
+            publications.map((publication) => (
+              <button
+                className={`w-full rounded-[1.4rem] border p-5 text-left transition ${
+                  selectedPublicationId === publication.id
+                    ? "border-[rgba(23,54,45,0.24)] bg-[rgba(255,250,243,0.92)] shadow-[0_18px_36px_rgba(15,32,24,0.08)]"
+                    : "border-[rgba(23,54,45,0.1)] bg-white/72 hover:bg-[rgba(255,250,243,0.82)]"
+                }`}
+                key={publication.id}
+                onClick={() => setSelectedPublicationId(publication.id)}
+                type="button"
+              >
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <p className="text-base font-semibold text-[var(--color-green-deep)]">
+                      {publication.title}
+                    </p>
+                    <p className="mt-1 text-sm text-[var(--color-muted)]">
+                      /publicacoes/{publication.slug}
+                    </p>
+                    <p className="mt-3 text-sm leading-7 text-[var(--color-green-deep)]">
+                      {publication.excerpt}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-2 text-xs uppercase tracking-[0.14em] text-[var(--color-red)]">
+                    {selectedPublicationId === publication.id ? (
+                      <span className="text-[var(--color-green-deep)]">
+                        Selecionada para edição
+                      </span>
+                    ) : (
+                      <span>Selecionar para editar</span>
+                    )}
+                    <span>{formatStatusLabel(publication.status)}</span>
+                    {publication.featured ? <span>Destaque na home</span> : null}
+                    {publication.publishedAt ? (
+                      <span>{formatDateTime(publication.publishedAt)}</span>
+                    ) : (
+                      <span>Sem publicação</span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            ))
+          ) : (
+            <p className="text-sm leading-7 text-[var(--color-muted)]">
+              Nenhuma publicação foi criada no acervo administrativo ainda.
+            </p>
+          )}
+        </div>
+      </article>
+
+      <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-[rgba(255,248,239,0.82)] p-6">
+        <PublicationEditorForm
+          action={action}
+          isPending={isPending}
+          key={formKey}
+          publication={selectedPublication}
+          state={state}
+        />
+      </article>
+    </div>
+  );
+}
+
+function PublicationEditorForm({
+  action,
+  isPending,
+  publication,
+  state,
+}: {
+  action: (formData: FormData) => void;
+  isPending: boolean;
+  publication: AdminPublicationRecord | null;
+  state: AdminPublicationsActionState;
+}) {
+  const [coverPreviewUrl, setCoverPreviewUrl] = useState<string | null>(
+    publication?.coverImageUrl ?? null,
+  );
+  const [coverValidationText, setCoverValidationText] = useState<string>(
+    publication?.coverImagePath
+      ? "A capa atual será mantida se nenhum arquivo novo for enviado."
+      : `Use JPG, PNG ou WEBP com até 5 MB. Recomendação: ${publicationCoverRecommendedRatio}, no mínimo ${publicationCoverMinimumWidth}x${publicationCoverMinimumHeight}.`,
+  );
+
+  async function handleCoverFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      setCoverPreviewUrl(publication?.coverImageUrl ?? null);
+      setCoverValidationText(
+        publication?.coverImagePath
+          ? "A capa atual será mantida se nenhum arquivo novo for enviado."
+          : `Use JPG, PNG ou WEBP com até 5 MB. Recomendação: ${publicationCoverRecommendedRatio}, no mínimo ${publicationCoverMinimumWidth}x${publicationCoverMinimumHeight}.`,
+      );
+      return;
+    }
+
+    if (
+      !(publicationCoverAcceptedMimeTypes as readonly string[]).includes(file.type)
+    ) {
+      setCoverPreviewUrl(publication?.coverImageUrl ?? null);
+      setCoverValidationText("Formato inválido. Use JPG, PNG ou WEBP.");
+      event.target.value = "";
+      return;
+    }
+
+    if (file.size > publicationCoverMaxFileSizeInBytes) {
+      setCoverPreviewUrl(publication?.coverImageUrl ?? null);
+      setCoverValidationText("A capa deve ter no máximo 5 MB.");
+      event.target.value = "";
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    const image = new Image();
+
+    image.onload = () => {
+      const isHorizontal = image.width > image.height;
+      const meetsMinimumSize =
+        image.width >= publicationCoverMinimumWidth &&
+        image.height >= publicationCoverMinimumHeight;
+
+      if (!isHorizontal) {
+        setCoverValidationText(
+          "A imagem precisa ser horizontal para funcionar bem nos cards e na home.",
+        );
+      } else if (!meetsMinimumSize) {
+        setCoverValidationText(
+          `A imagem está abaixo do mínimo recomendado de ${publicationCoverMinimumWidth}x${publicationCoverMinimumHeight}.`,
+        );
+      } else {
+        setCoverValidationText(
+          `Imagem pronta para envio. Recomendação editorial: proporção próxima de ${publicationCoverRecommendedRatio}.`,
+        );
+      }
+
+      setCoverPreviewUrl(objectUrl);
+    };
+
+    image.onerror = () => {
+      setCoverPreviewUrl(publication?.coverImageUrl ?? null);
+      setCoverValidationText("Não foi possível ler a prévia dessa imagem.");
+      URL.revokeObjectURL(objectUrl);
+    };
+
+    image.src = objectUrl;
+  }
+
+  return (
+    <>
+      <p className="section-eyebrow">Editor</p>
+      <h3 className="mt-3 text-2xl font-heading text-[var(--color-green-deep)]">
+        {publication ? "Editar publicação" : "Criar publicação"}
+      </h3>
+
+      <form action={action} className="mt-6 grid gap-4">
+        <input name="id" type="hidden" value={publication?.id ?? ""} />
+
+        <label className="form-field">
+          <span>Título</span>
+          <input
+            defaultValue={publication?.title ?? ""}
+            name="title"
+            placeholder="Título da notícia"
+            required
+          />
+        </label>
+
+        <label className="form-field">
+          <span className="flex items-center gap-2">
+            Link da publicação
+            <span className="relative inline-flex">
+              <button
+                aria-label="Explicação sobre o link da publicação"
+                className="grid h-5 w-5 place-items-center rounded-full border border-[rgba(23,54,45,0.18)] text-[0.72rem] font-semibold leading-none text-[var(--color-green-deep)] transition hover:bg-[rgba(255,250,243,0.92)]"
+                title="Este texto será usado no endereço da página. Exemplo: /publicacoes/festa-de-maio-2026. Se deixar em branco, o sistema cria automaticamente a partir do título."
+                type="button"
+              >
+                i
+              </button>
+            </span>
+          </span>
+          <input
+            defaultValue={publication?.slug ?? ""}
+            name="slug"
+            placeholder="deixe em branco para gerar automaticamente"
+          />
+        </label>
+
+        <label className="form-field">
+          <span>Resumo</span>
+          <textarea
+            className="min-h-24"
+            defaultValue={publication?.excerpt ?? ""}
+            name="excerpt"
+            placeholder="Resumo curto para home e listagem"
+            required
+          />
+        </label>
+
+        <label className="form-field">
+          <span>Corpo</span>
+          <textarea
+            className="min-h-48"
+            defaultValue={publication?.body ?? ""}
+            name="body"
+            placeholder="Texto completo da publicação"
+            required
+          />
+        </label>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <label className="form-field">
+            <span>Categoria</span>
+            <input
+              defaultValue={publication?.category ?? ""}
+              name="category"
+              placeholder="Notícia, evento, memória..."
+            />
+          </label>
+
+          <label className="form-field">
+            <span>Autor</span>
+            <input
+              defaultValue={publication?.authorName ?? ""}
+              name="authorName"
+              placeholder="Nome institucional ou pessoa responsável"
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-4 rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-white/72 p-4">
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_12rem]">
+            <div className="grid gap-4">
+              <label className="form-field">
+                <span>Imagem de capa</span>
+                <input
+                  accept={publicationCoverAcceptedMimeTypes.join(",")}
+                  name="coverImageFile"
+                  onChange={handleCoverFileChange}
+                  type="file"
+                />
+              </label>
+
+              <label className="form-field">
+                <span>Texto alternativo da imagem</span>
+                <input
+                  defaultValue={publication?.coverImageAlt ?? ""}
+                  name="coverImageAlt"
+                  placeholder="Descreva a imagem de capa"
+                />
+              </label>
+
+              <p className="text-sm leading-7 text-[var(--color-muted)]">
+                {coverValidationText}
+              </p>
+            </div>
+
+            <div className="rounded-[1.2rem] border border-[rgba(23,54,45,0.08)] bg-[rgba(255,250,243,0.74)] p-3">
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.14em] text-[var(--color-red)]">
+                Prévia
+              </p>
+              <div className="mt-3 overflow-hidden rounded-[1rem] border border-[rgba(23,54,45,0.08)] bg-[linear-gradient(135deg,#20452e_0%,#8b1e28_45%,#d6b06a_100%)]">
+                {coverPreviewUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    alt={publication?.coverImageAlt || "Prévia da capa"}
+                    className="aspect-[16/10] h-auto w-full object-cover"
+                    src={coverPreviewUrl}
+                  />
+                ) : (
+                  <div className="aspect-[16/10] w-full" />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <label className="form-field">
+            <span>Status</span>
+            <select
+              className="rounded-2xl border border-[rgba(23,54,45,0.12)] bg-white/88 px-4 py-3 text-[var(--color-ink)]"
+              defaultValue={publication?.status ?? "draft"}
+              name="status"
+            >
+              <option value="draft">draft</option>
+              <option value="published">published</option>
+              <option value="archived">archived</option>
+            </select>
+          </label>
+
+          <label className="form-field">
+            <span>Publicada em</span>
+            <input
+              defaultValue={formatDatetimeLocalValue(publication?.publishedAt ?? null)}
+              name="publishedAt"
+              type="datetime-local"
+            />
+          </label>
+        </div>
+
+        <label className="form-field">
+          <span>SEO title</span>
+          <input
+            defaultValue={publication?.seoTitle ?? ""}
+            name="seoTitle"
+            placeholder="Opcional"
+          />
+        </label>
+
+        <label className="form-field">
+          <span>SEO description</span>
+          <textarea
+            className="min-h-20"
+            defaultValue={publication?.seoDescription ?? ""}
+            name="seoDescription"
+            placeholder="Opcional"
+          />
+        </label>
+
+        <label className="flex items-center gap-3 rounded-[1.2rem] border border-[rgba(23,54,45,0.1)] bg-white/72 px-4 py-3 text-sm font-medium text-[var(--color-green-deep)]">
+          <input
+            defaultChecked={publication?.featured ?? false}
+            name="featured"
+            type="checkbox"
+          />
+          Marcar como destaque principal da home
+        </label>
+
+        <ActionFeedback state={state} />
+
+        <button className="primary-button" disabled={isPending} type="submit">
+          {isPending
+            ? "Salvando..."
+            : publication
+              ? "Salvar publicação"
+              : "Criar publicação"}
+        </button>
+      </form>
+    </>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-[1.2rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,250,243,0.72)] px-4 py-3">
+      <p className="text-[0.72rem] font-semibold uppercase tracking-[0.16em] text-[var(--color-red)]">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-semibold text-[var(--color-green-deep)]">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function ActionFeedback({ state }: { state: AdminPublicationsActionState }) {
+  if (state.error) {
+    return <p className="text-sm font-medium text-[var(--color-red-deep)]">{state.error}</p>;
+  }
+
+  if (state.success) {
+    return (
+      <p className="text-sm font-medium text-[var(--color-green-deep)]">{state.success}</p>
+    );
+  }
+
+  return null;
+}
+
+function formatStatusLabel(status: string) {
+  if (status === "published") {
+    return "Publicada";
+  }
+
+  if (status === "archived") {
+    return "Arquivada";
+  }
+
+  return "Rascunho";
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatDatetimeLocalValue(value: string | null) {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}

--- a/src/components/associate-area-manager.tsx
+++ b/src/components/associate-area-manager.tsx
@@ -23,6 +23,7 @@ type DependentDraft = {
   cpf: string;
   fullName: string;
   id: string;
+  membershipNumber: string | null;
   nationality: Nationality | "";
   rg: string;
 };
@@ -41,6 +42,7 @@ type AssociateDraft = {
   dependents: DependentDraft[];
   email: string;
   fullName: string;
+  membershipNumber: string | null;
   nationality: Nationality | "";
   observation: string;
   phone: string;
@@ -136,6 +138,7 @@ export function AssociateAreaManager({
       category: draft.category || "Não informada",
       cpf: draft.cpf || "Não informado",
       fullName: draft.fullName || "Nome em atualização",
+      membershipNumber: draft.membershipNumber,
       nationality: draft.nationality || "Não informada",
       photoUrl: draft.photoUrl,
       profileId: profile.profileId,
@@ -178,6 +181,7 @@ export function AssociateAreaManager({
           cpf: "",
           fullName: "",
           id: createClientId(),
+          membershipNumber: null,
           nationality: "",
           rg: "",
         },
@@ -334,6 +338,7 @@ export function AssociateAreaManager({
       cpf: dependent.cpf || null,
       fullName: dependent.fullName,
       id: dependent.id,
+      membershipNumber: dependent.membershipNumber,
       nationality: dependent.nationality || null,
       rg: dependent.rg || null,
     })),
@@ -371,6 +376,10 @@ export function AssociateAreaManager({
                       value={draft.fullName}
                     />
                     <ReadOnlyField label="Email" value={draft.email} />
+                    <ReadOnlyField
+                      label="Matrícula"
+                      value={draft.membershipNumber || "Será atribuída automaticamente"}
+                    />
                     <SelectField
                       label="Categoria"
                       name="category"
@@ -568,6 +577,9 @@ export function AssociateAreaManager({
                         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                           <p className="text-base font-semibold text-[var(--color-green-deep)]">
                             Dependente {index + 1}
+                          </p>
+                          <p className="text-sm font-medium text-[var(--color-muted)]">
+                            Matrícula: {dependent.membershipNumber || "Será atribuída automaticamente"}
                           </p>
                           <button
                             className="rounded-full border border-[rgba(154,31,43,0.2)] bg-[rgba(154,31,43,0.08)] px-5 py-2 text-sm font-semibold text-[var(--color-red-deep)] transition hover:bg-[rgba(154,31,43,0.14)]"
@@ -892,6 +904,7 @@ export function AssociateAreaManager({
                     category: draft.category || "Não informada",
                     cpf: draft.cpf || "Não informado",
                     fullName: draft.fullName || "Nome em atualização",
+                    membershipNumber: draft.membershipNumber,
                     nationality: draft.nationality || "Não informada",
                     photoUrl: draft.photoUrl,
                     profileId: profile.profileId,
@@ -914,6 +927,7 @@ async function downloadAssociateCardPng({
   category,
   cpf,
   fullName,
+  membershipNumber,
   nationality,
   photoUrl,
   profileId,
@@ -922,6 +936,7 @@ async function downloadAssociateCardPng({
   category: string;
   cpf: string;
   fullName: string;
+  membershipNumber: string | null;
   nationality: string;
   photoUrl: string | null;
   profileId: string;
@@ -931,6 +946,7 @@ async function downloadAssociateCardPng({
     category,
     cpf,
     fullName,
+    membershipNumber,
     nationality,
     photoUrl,
     profileId,
@@ -951,6 +967,7 @@ async function createAssociateCardPngDataUrl({
   category,
   cpf,
   fullName,
+  membershipNumber,
   nationality,
   photoUrl,
   profileId,
@@ -959,6 +976,7 @@ async function createAssociateCardPngDataUrl({
   category: string;
   cpf: string;
   fullName: string;
+  membershipNumber: string | null;
   nationality: string;
   photoUrl: string | null;
   profileId: string;
@@ -1041,7 +1059,7 @@ async function createAssociateCardPngDataUrl({
   context.fillText("ASSOCIADO", 316, 114);
 
   context.textAlign = "right";
-  context.fillText(formatAssociateCardId(profileId), 704, 72);
+  context.fillText(formatAssociateCardId(profileId, membershipNumber), 704, 72);
   context.textAlign = "left";
 
   context.fillStyle = "#173b2f";
@@ -1350,7 +1368,14 @@ function ReadOnlyField({ label, value }: { label: string; value: string }) {
   return (
     <label className="form-field">
       <span>{label}</span>
-      <input readOnly value={value} />
+      <input
+        aria-readonly="true"
+        className="cursor-default bg-[rgba(247,242,232,0.96)] text-[var(--color-green-deep)]"
+        disabled
+        readOnly
+        tabIndex={-1}
+        value={value}
+      />
     </label>
   );
 }
@@ -1438,11 +1463,13 @@ function createDraft(profile: AssociateProfileRecord): AssociateDraft {
       cpf: dependent.cpf ?? "",
       fullName: dependent.fullName,
       id: dependent.id,
+      membershipNumber: dependent.membershipNumber ?? null,
       nationality: dependent.nationality ?? "",
       rg: dependent.rg ?? "",
     })),
     email: profile.email,
     fullName: profile.fullName,
+    membershipNumber: profile.membershipNumber ?? null,
     nationality: profile.nationality ?? "",
     observation: profile.observation,
     phone: profile.phone,
@@ -1474,7 +1501,11 @@ function formatDate(value: string) {
   return `${day}/${month}/${year}`;
 }
 
-function formatAssociateCardId(profileId: string) {
+function formatAssociateCardId(profileId: string, membershipNumber: string | null) {
+  if (membershipNumber) {
+    return `AAJF-${membershipNumber}`;
+  }
+
   const suffix = profileId.replace(/-/g, "").slice(-6).toUpperCase();
   return `AAJF-${suffix || "TEMP"}`;
 }

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -3,12 +3,13 @@ import Link from "next/link";
 import {
   communityMetrics,
   heroHighlights,
-  posts,
   siteConfig,
 } from "@/lib/site-content";
+import type { PublicationRecord } from "@/lib/supabase/publications";
 
-export function Hero() {
-  const featuredPost = posts[0];
+export function Hero({ featuredPost }: { featuredPost: PublicationRecord }) {
+  const coverImageUrl = featuredPost.coverImageUrl?.trim() || null;
+  const coverImageAlt = featuredPost.coverImageAlt?.trim() || featuredPost.title;
 
   return (
     <section id="inicio" className="section-shell pt-6 sm:pt-8">
@@ -61,25 +62,28 @@ export function Hero() {
 
             <div className="relative overflow-hidden rounded-[2.1rem] border border-white/55 bg-[rgba(255,250,245,0.74)] p-4 shadow-[0_32px_80px_rgba(19,29,28,0.16)] backdrop-blur">
               <div className="relative aspect-[4/3] overflow-hidden rounded-[1.7rem]">
-                <Image
-                  src={featuredPost.image!}
-                  alt="Integrantes do Grupo Schmetterling em apresentacao cultural"
-                  fill
-                  className="object-cover"
-                  priority
-                  sizes="(max-width: 1024px) 100vw, 42vw"
-                />
+                {coverImageUrl ? (
+                  <Image
+                    src={coverImageUrl}
+                    alt={coverImageAlt}
+                    fill
+                    className="object-cover"
+                    priority
+                    sizes="(max-width: 1024px) 100vw, 42vw"
+                  />
+                ) : (
+                  <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(232,188,90,0.24),transparent_36%),linear-gradient(135deg,rgba(14,23,22,0.98),rgba(129,27,31,0.92),rgba(228,190,112,0.72))]" />
+                )}
                 <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(18,27,25,0.04),rgba(18,27,25,0.78))]" />
                 <div className="absolute inset-x-0 bottom-0 p-6 text-white sm:p-7">
                   <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[var(--color-gold-strong)]">
-                    Tradição em movimento
+                    {featuredPost.featured ? "Publicação em destaque" : "Publicação"}
                   </p>
                   <h2 className="mt-3 font-heading text-3xl leading-tight">
-                    Grupo Schmetterling
+                    {featuredPost.title}
                   </h2>
                   <p className="mt-3 max-w-md text-sm leading-7 text-[rgba(255,247,238,0.9)]">
-                    Figurinos, alegria e coreografias que aproximam a cidade de uma
-                    herança cultural viva.
+                    {featuredPost.excerpt}
                   </p>
                 </div>
               </div>

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -5,22 +5,23 @@ import { Hero } from "@/components/hero";
 import { PublicationCard } from "@/components/publication-card";
 import { SectionTitle } from "@/components/section-title";
 import { TestimonialCard } from "@/components/testimonial-card";
+import type { PublicationRecord } from "@/lib/supabase/publications";
+import { formatPublicationDate } from "@/lib/supabase/publications";
 import {
   aboutContent,
   accessAreas,
   essenceItems,
-  posts,
   schmetterlingContent,
   siteConfig,
   testimonials,
 } from "@/lib/site-content";
 
-export function HomeContent() {
+export function HomeContent({ posts }: { posts: PublicationRecord[] }) {
   const [featuredPost, ...otherPosts] = posts;
 
   return (
     <main className="flex-1 pb-20">
-      <Hero />
+      <Hero featuredPost={featuredPost} />
 
       <section id="essencia" className="section-shell section-spacing">
         <SectionTitle
@@ -138,8 +139,10 @@ export function HomeContent() {
           <PublicationCard
             title={featuredPost.title}
             excerpt={featuredPost.excerpt}
-            date={featuredPost.date}
-            image={featuredPost.image}
+            date={formatPublicationDate(featuredPost.publishedAt)}
+            href={`/publicacoes/${featuredPost.slug}`}
+            image={featuredPost.coverImageUrl}
+            imageAlt={featuredPost.coverImageAlt}
             featured
           />
           {otherPosts.map((post) => (
@@ -147,8 +150,10 @@ export function HomeContent() {
               key={post.slug}
               title={post.title}
               excerpt={post.excerpt}
-              date={post.date}
-              image={post.image}
+              date={formatPublicationDate(post.publishedAt)}
+              href={`/publicacoes/${post.slug}`}
+              image={post.coverImageUrl}
+              imageAlt={post.coverImageAlt}
             />
           ))}
         </div>

--- a/src/components/publication-card.tsx
+++ b/src/components/publication-card.tsx
@@ -2,17 +2,21 @@ import Image from "next/image";
 import Link from "next/link";
 
 type PublicationCardProps = {
+  href?: string;
   title: string;
   excerpt: string;
   date: string;
+  imageAlt?: string | null;
   image?: string | null;
   featured?: boolean;
 };
 
 export function PublicationCard({
+  href = "/publicacoes",
   title,
   excerpt,
   date,
+  imageAlt,
   image,
   featured = false,
 }: PublicationCardProps) {
@@ -26,7 +30,7 @@ export function PublicationCard({
         <div className="relative aspect-[16/10]">
           <Image
             src={image}
-            alt={title}
+            alt={imageAlt || title}
             fill
             className="object-cover"
             sizes="(max-width: 1024px) 100vw, 60vw"
@@ -48,8 +52,8 @@ export function PublicationCard({
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--color-muted-strong)]">
             {date}
           </p>
-          <Link className="text-sm font-semibold text-[var(--color-green-deep)]" href="/publicacoes">
-            Ver publicações
+          <Link className="text-sm font-semibold text-[var(--color-green-deep)]" href={href}>
+            Ler publicação
           </Link>
         </div>
       </div>

--- a/src/lib/publications-content.ts
+++ b/src/lib/publications-content.ts
@@ -1,0 +1,44 @@
+export const publicationSeedPosts = [
+  {
+    slug: "tradicao-em-movimento",
+    title: "Tradição em Movimento: Conheça o Grupo Schmetterling!",
+    excerpt:
+      "Nosso grupo de danças folclóricas Schmetterling mantém viva a cultura alemã com apresentações cheias de alegria, tradição e figurinos marcantes.",
+    body: [
+      "Nosso grupo de danças folclóricas Schmetterling mantém viva a cultura alemã com apresentações cheias de alegria e tradição.",
+      "Através da dança, levamos a história e os costumes alemães para eventos culturais, festas típicas e celebrações, sempre com figurinos autênticos e coreografias vibrantes.",
+      "Esse trabalho fortalece a presença da associação em Juiz de Fora e aproxima o público de uma herança cultural preservada com dedicação.",
+    ],
+    date: "18 de janeiro de 2023",
+    featured: true,
+    image: "/images/publicacoes/1/162257-jpg.webp",
+  },
+  {
+    slug: "preservando-a-cultura-alema",
+    title: "Preservando a Cultura Alemã em Juiz de Fora",
+    excerpt:
+      "A Associação Alemã de Juiz de Fora tem orgulho de preservar e difundir as tradições germânicas por meio da cultura, da dança e da confraternização.",
+    body: [
+      "A Associação Alemã de Juiz de Fora tem orgulho de preservar e difundir as tradições germânicas por meio da cultura, da dança e da confraternização.",
+      "Nosso compromisso é manter viva a rica herança alemã, promovendo a união entre descendentes e admiradores da cultura.",
+      "Cada ação reforça o valor da memória, do encontro entre gerações e da presença cultural da associação na cidade.",
+    ],
+    date: "18 de janeiro de 2023",
+    featured: false,
+    image: null,
+  },
+  {
+    slug: "faca-parte-da-nossa-historia",
+    title: "Faça Parte da Nossa História!",
+    excerpt:
+      "Se você ama a cultura alemã e quer vivenciá-la de perto, a associação abre espaço para participação, convivência e construção de novas memórias.",
+    body: [
+      "Se você ama a cultura alemã e quer vivenciá-la de perto, a associação oferece um espaço de participação, convivência e aprendizado.",
+      "A associação reúne pessoas interessadas em manter vivas tradições, histórias e expressões culturais por meio de encontros e atividades.",
+      "É um convite para conhecer mais de perto a cultura alemã em Juiz de Fora e fazer parte dessa história.",
+    ],
+    date: "18 de janeiro de 2023",
+    featured: false,
+    image: null,
+  },
+] as const;

--- a/src/lib/site-content.ts
+++ b/src/lib/site-content.ts
@@ -1,3 +1,5 @@
+import { publicationSeedPosts } from "@/lib/publications-content";
+
 export const siteConfig = {
   name: "Associação Alemã de Juiz de Fora",
   legalName: "Associação Cultural e Recreativa Brasil-Alemanha",
@@ -110,50 +112,7 @@ export const accessAreas = [
   },
 ];
 
-export const posts = [
-  {
-    slug: "tradicao-em-movimento",
-    title: "Tradição em Movimento: Conheça o Grupo Schmetterling!",
-    excerpt:
-      "Nosso grupo de danças folclóricas Schmetterling mantém viva a cultura alemã com apresentações cheias de alegria, tradição e figurinos marcantes.",
-    body: [
-      "Nosso grupo de danças folclóricas Schmetterling mantém viva a cultura alemã com apresentações cheias de alegria e tradição.",
-      "Através da dança, levamos a história e os costumes alemães para eventos culturais, festas típicas e celebrações, sempre com figurinos autênticos e coreografias vibrantes.",
-      "Esse trabalho fortalece a presença da associação em Juiz de Fora e aproxima o público de uma herança cultural preservada com dedicação.",
-    ],
-    date: "18 de janeiro de 2023",
-    image: "/images/publicacoes/1/162257-jpg.webp",
-    featured: true,
-  },
-  {
-    slug: "preservando-a-cultura-alema",
-    title: "Preservando a Cultura Alemã em Juiz de Fora",
-    excerpt:
-      "A Associação Alemã de Juiz de Fora tem orgulho de preservar e difundir as tradições germânicas por meio da cultura, da dança e da confraternização.",
-    body: [
-      "A Associação Alemã de Juiz de Fora tem orgulho de preservar e difundir as tradições germânicas por meio da cultura, da dança e da confraternização.",
-      "Nosso compromisso é manter viva a rica herança alemã, promovendo a união entre descendentes e admiradores da cultura.",
-      "Cada ação reforça o valor da memória, do encontro entre gerações e da presença cultural da associação na cidade.",
-    ],
-    date: "18 de janeiro de 2023",
-    image: null,
-    featured: false,
-  },
-  {
-    slug: "faca-parte-da-nossa-historia",
-    title: "Faça Parte da Nossa História!",
-    excerpt:
-      "Se você ama a cultura alemã e quer vivenciá-la de perto, a associação abre espaço para participação, convivência e construção de novas memórias.",
-    body: [
-      "Se você ama a cultura alemã e quer vivenciá-la de perto, a associação oferece um espaço de participação, convivência e aprendizado.",
-      "A associação reúne pessoas interessadas em manter vivas tradições, histórias e expressões culturais por meio de encontros e atividades.",
-      "É um convite para conhecer mais de perto a cultura alemã em Juiz de Fora e fazer parte dessa história.",
-    ],
-    date: "18 de janeiro de 2023",
-    image: null,
-    featured: false,
-  },
-];
+export const posts = publicationSeedPosts;
 
 export const testimonials = [
   {

--- a/src/lib/supabase/admin-associates.ts
+++ b/src/lib/supabase/admin-associates.ts
@@ -67,13 +67,13 @@ export async function getAdminAssociatesData(): Promise<AdminAssociatesData> {
         .schema("aajf")
         .from("associate_profiles")
         .select(
-          "id, profile_id, full_name, category, cpf, rg, phone, birth_date, nationality, cep, street, number, complement, neighborhood, city, state, observation, term_accepted, photo_url",
+          "id, profile_id, membership_number, full_name, category, cpf, rg, phone, birth_date, nationality, cep, street, number, complement, neighborhood, city, state, observation, term_accepted, photo_url",
         ),
       supabase
         .schema("aajf")
         .from("associate_dependents")
         .select(
-          "id, associate_profile_id, full_name, category, cpf, rg, birth_date, nationality",
+          "id, associate_profile_id, membership_number, full_name, category, cpf, rg, birth_date, nationality",
         ),
     ]);
 
@@ -99,6 +99,7 @@ export async function getAdminAssociatesData(): Promise<AdminAssociatesData> {
       cpf: dependent.cpf,
       fullName: dependent.full_name,
       id: dependent.id,
+      membershipNumber: dependent.membership_number ?? null,
       nationality: dependent.nationality as Nationality | null,
       rg: dependent.rg,
     });
@@ -121,6 +122,7 @@ export async function getAdminAssociatesData(): Promise<AdminAssociatesData> {
         cpf: profile.cpf ?? "",
         dependents: dependentsByAssociateProfileId.get(profile.id) ?? [],
         fullName: profile.full_name ?? "",
+        membershipNumber: profile.membership_number ?? null,
         nationality: profile.nationality as Nationality | null,
         observation: profile.observation ?? "",
         phone: profile.phone ?? "",

--- a/src/lib/supabase/admin-publications.ts
+++ b/src/lib/supabase/admin-publications.ts
@@ -1,0 +1,103 @@
+import { getAdminAccess, type AdminAccess } from "@/lib/supabase/access";
+import type { PublicationStatus } from "@/lib/supabase/publications";
+import { publicationCoverBucketName } from "@/lib/supabase/publication-shared";
+import { createClient } from "@/lib/supabase/server";
+
+export type AdminPublicationRecord = {
+  authorName: string | null;
+  body: string;
+  category: string | null;
+  coverImageAlt: string | null;
+  coverImagePath: string | null;
+  coverImageUrl: string | null;
+  createdAt: string | null;
+  excerpt: string;
+  featured: boolean;
+  id: string;
+  publishedAt: string | null;
+  seoDescription: string | null;
+  seoTitle: string | null;
+  slug: string;
+  status: PublicationStatus;
+  title: string;
+  updatedAt: string | null;
+};
+
+export type AdminPublicationsData =
+  | {
+      access: Extract<
+        AdminAccess,
+        { status: "unconfigured" | "unauthenticated" | "denied" }
+      >;
+    }
+  | {
+      access: Extract<AdminAccess, { status: "authorized" }>;
+      publications: AdminPublicationRecord[];
+    };
+
+export async function getAdminPublicationsData(): Promise<AdminPublicationsData> {
+  const access = await getAdminAccess();
+
+  if (access.status !== "authorized") {
+    return { access };
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .schema("aajf")
+    .from("publications")
+    .select(
+      "id, slug, title, excerpt, body, cover_image_url, cover_image_alt, published_at, featured, status, author_name, category, seo_title, seo_description, created_at, updated_at",
+    )
+    .order("featured", { ascending: false })
+    .order("published_at", { ascending: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return {
+    access,
+    publications: (data ?? []).map((publication) => ({
+      authorName: publication.author_name,
+      body: publication.body ?? "",
+      category: publication.category,
+      coverImageAlt: publication.cover_image_alt,
+      coverImagePath: publication.cover_image_url,
+      coverImageUrl: resolvePublicationCoverUrl(supabase, publication.cover_image_url),
+      createdAt: publication.created_at,
+      excerpt: publication.excerpt,
+      featured: publication.featured ?? false,
+      id: publication.id,
+      publishedAt: publication.published_at,
+      seoDescription: publication.seo_description,
+      seoTitle: publication.seo_title,
+      slug: publication.slug,
+      status: publication.status as PublicationStatus,
+      title: publication.title,
+      updatedAt: publication.updated_at,
+    })),
+  };
+}
+
+function resolvePublicationCoverUrl(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  coverImageValue: string | null | undefined,
+) {
+  const normalized = coverImageValue?.trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (/^https?:\/\//i.test(normalized)) {
+    return normalized;
+  }
+
+  const { data } = supabase.storage
+    .from(publicationCoverBucketName)
+    .getPublicUrl(normalized);
+
+  return data.publicUrl;
+}

--- a/src/lib/supabase/associate-profile-shared.ts
+++ b/src/lib/supabase/associate-profile-shared.ts
@@ -34,6 +34,7 @@ export type AssociateDependentRecord = {
   cpf: string | null;
   fullName: string;
   id: string;
+  membershipNumber: string | null;
   nationality: Nationality | null;
   rg: string | null;
 };
@@ -52,6 +53,7 @@ export type AssociateProfileRecord = {
   dependents: AssociateDependentRecord[];
   email: string;
   fullName: string;
+  membershipNumber: string | null;
   nationality: Nationality | null;
   observation: string;
   phone: string;

--- a/src/lib/supabase/associate-profile.ts
+++ b/src/lib/supabase/associate-profile.ts
@@ -64,7 +64,7 @@ export async function getAssociateAreaData(): Promise<AssociateAreaData> {
         .schema("aajf")
         .from("associate_profiles")
         .select(
-          "id, photo_url, full_name, category, cpf, rg, phone, birth_date, nationality, cep, street, number, complement, neighborhood, city, state, observation, term_accepted, associate_dependents(id, full_name, category, cpf, rg, birth_date, nationality)",
+          "id, membership_number, photo_url, full_name, category, cpf, rg, phone, birth_date, nationality, cep, street, number, complement, neighborhood, city, state, observation, term_accepted, associate_dependents(id, membership_number, full_name, category, cpf, rg, birth_date, nationality)",
         )
         .eq("profile_id", user.id)
         .maybeSingle(),
@@ -86,6 +86,7 @@ export async function getAssociateAreaData(): Promise<AssociateAreaData> {
     cpf: dependent.cpf,
     fullName: dependent.full_name,
     id: dependent.id,
+    membershipNumber: dependent.membership_number ?? null,
     nationality: dependent.nationality,
     rg: dependent.rg,
   }));
@@ -113,6 +114,7 @@ export async function getAssociateAreaData(): Promise<AssociateAreaData> {
       dependents,
       email: profileData?.email ?? user.email ?? "",
       fullName: associateProfileData?.full_name ?? profileData?.full_name ?? "",
+      membershipNumber: associateProfileData?.membership_number ?? null,
       nationality: associateProfileData?.nationality ?? null,
       observation: associateProfileData?.observation ?? "",
       phone: associateProfileData?.phone ?? "",

--- a/src/lib/supabase/publication-shared.ts
+++ b/src/lib/supabase/publication-shared.ts
@@ -1,0 +1,11 @@
+export const publicationCoverBucketName = "publication-cover-images";
+export const publicationCoverAcceptedMimeTypes = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
+export const publicationCoverMaxFileSizeInBytes = 5 * 1024 * 1024;
+export const publicationCoverMinimumWidth = 1600;
+export const publicationCoverMinimumHeight = 1000;
+export const publicationCoverRecommendedRatio = "16:10";
+

--- a/src/lib/supabase/publications.ts
+++ b/src/lib/supabase/publications.ts
@@ -1,0 +1,170 @@
+import "server-only";
+
+import { notFound } from "next/navigation";
+import { publicationSeedPosts } from "@/lib/publications-content";
+import { isSupabaseConfigured } from "@/lib/supabase/config";
+import { publicationCoverBucketName } from "@/lib/supabase/publication-shared";
+import { createClient } from "@/lib/supabase/server";
+
+export type PublicationStatus = "draft" | "published" | "archived";
+
+export type PublicationRecord = {
+  authorName: string | null;
+  body: string[];
+  category: string | null;
+  coverImageAlt: string | null;
+  coverImageUrl: string | null;
+  createdAt: string | null;
+  excerpt: string;
+  featured: boolean;
+  id: string;
+  publishedAt: string | null;
+  seoDescription: string | null;
+  seoTitle: string | null;
+  slug: string;
+  status: PublicationStatus;
+  title: string;
+  updatedAt: string | null;
+};
+
+function normalizeOptionalText(value: string | null | undefined) {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function normalizeSeedPosts(): PublicationRecord[] {
+  return publicationSeedPosts.map((post, index) => ({
+    authorName: "Associação Alemã de Juiz de Fora",
+    body: [...post.body],
+    category: null,
+    coverImageAlt: post.title,
+    coverImageUrl: post.image,
+    createdAt: null,
+    excerpt: post.excerpt,
+    featured: post.featured,
+    id: `seed-${index + 1}`,
+    publishedAt: "2023-01-18T00:00:00.000Z",
+    seoDescription: null,
+    seoTitle: null,
+    slug: post.slug,
+    status: "published",
+    title: post.title,
+    updatedAt: null,
+  }));
+}
+
+function formatBody(body: string | string[] | null): string[] {
+  if (Array.isArray(body)) {
+    return body.filter(Boolean);
+  }
+
+  if (!body) {
+    return [];
+  }
+
+  return body
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+}
+
+function resolvePublicationCoverUrl(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  coverImageValue: string | null | undefined,
+) {
+  const normalized = normalizeOptionalText(coverImageValue);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (/^https?:\/\//i.test(normalized)) {
+    return normalized;
+  }
+
+  const { data } = supabase.storage
+    .from(publicationCoverBucketName)
+    .getPublicUrl(normalized);
+
+  return data.publicUrl;
+}
+
+async function fetchDatabasePublications() {
+  if (!isSupabaseConfigured()) {
+    return null;
+  }
+
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .schema("aajf")
+      .from("publications")
+      .select(
+        "id, slug, title, excerpt, body, cover_image_url, cover_image_alt, published_at, featured, status, author_name, category, seo_title, seo_description, created_at, updated_at",
+      )
+      .eq("status", "published")
+      .order("featured", { ascending: false })
+      .order("published_at", { ascending: false })
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      return null;
+    }
+
+    return (data ?? []).map((publication) => ({
+      authorName: normalizeOptionalText(publication.author_name),
+      body: formatBody(publication.body),
+      category: normalizeOptionalText(publication.category),
+      coverImageAlt:
+        normalizeOptionalText(publication.cover_image_alt) ?? publication.title,
+      coverImageUrl: resolvePublicationCoverUrl(
+        supabase,
+        publication.cover_image_url,
+      ),
+      createdAt: publication.created_at,
+      excerpt: publication.excerpt,
+      featured: publication.featured ?? false,
+      id: publication.id,
+      publishedAt: publication.published_at,
+      seoDescription: normalizeOptionalText(publication.seo_description),
+      seoTitle: normalizeOptionalText(publication.seo_title),
+      slug: publication.slug,
+      status: publication.status as PublicationStatus,
+      title: publication.title,
+      updatedAt: publication.updated_at,
+    })) satisfies PublicationRecord[];
+  } catch {
+    return null;
+  }
+}
+
+export async function getPublishedPublications(): Promise<PublicationRecord[]> {
+  const dbPublications = await fetchDatabasePublications();
+
+  if (dbPublications && dbPublications.length) {
+    return dbPublications;
+  }
+
+  return normalizeSeedPosts();
+}
+
+export async function getPublicationBySlug(slug: string): Promise<PublicationRecord> {
+  const publications = await getPublishedPublications();
+  const publication = publications.find((item) => item.slug === slug);
+
+  if (!publication) {
+    notFound();
+  }
+
+  return publication;
+}
+
+export function formatPublicationDate(value: string | null) {
+  if (!value) {
+    return "";
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "long",
+  }).format(new Date(value));
+}

--- a/supabase/migrations/20260504164000_create_publications.sql
+++ b/supabase/migrations/20260504164000_create_publications.sql
@@ -1,0 +1,68 @@
+create table if not exists aajf.publications (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  title text not null,
+  excerpt text not null,
+  body text not null,
+  cover_image_url text,
+  status text not null default 'draft',
+  featured boolean not null default false,
+  category text,
+  published_at timestamptz,
+  author_name text,
+  seo_title text,
+  seo_description text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint publications_status_check
+    check (status in ('draft', 'published', 'archived'))
+);
+
+create index if not exists publications_status_idx
+  on aajf.publications (status);
+
+create index if not exists publications_published_at_idx
+  on aajf.publications (published_at desc);
+
+create index if not exists publications_featured_idx
+  on aajf.publications (featured desc, published_at desc);
+
+drop trigger if exists set_publications_updated_at on aajf.publications;
+create trigger set_publications_updated_at
+before update on aajf.publications
+for each row execute function aajf.set_updated_at();
+
+alter table aajf.publications enable row level security;
+
+create policy "publications_select_published_public"
+on aajf.publications
+for select
+to anon, authenticated
+using (status = 'published');
+
+create policy "publications_insert_admin"
+on aajf.publications
+for insert
+to authenticated
+with check (app_private.is_active_admin(auth.uid()));
+
+create policy "publications_update_admin"
+on aajf.publications
+for update
+to authenticated
+using (app_private.is_active_admin(auth.uid()))
+with check (app_private.is_active_admin(auth.uid()));
+
+create policy "publications_delete_admin"
+on aajf.publications
+for delete
+to authenticated
+using (app_private.is_active_admin(auth.uid()));
+
+grant select
+  on table aajf.publications
+  to anon, authenticated;
+
+grant insert, update, delete
+  on table aajf.publications
+  to authenticated;

--- a/supabase/migrations/20260504183000_add_admin_select_policy_to_publications.sql
+++ b/supabase/migrations/20260504183000_add_admin_select_policy_to_publications.sql
@@ -1,0 +1,5 @@
+create policy "publications_select_admin"
+on aajf.publications
+for select
+to authenticated
+using (app_private.is_active_admin(auth.uid()));

--- a/supabase/migrations/20260505001000_add_publication_cover_alt.sql
+++ b/supabase/migrations/20260505001000_add_publication_cover_alt.sql
@@ -1,0 +1,2 @@
+alter table aajf.publications
+add column if not exists cover_image_alt text;

--- a/supabase/migrations/20260505002000_create_publication_cover_bucket.sql
+++ b/supabase/migrations/20260505002000_create_publication_cover_bucket.sql
@@ -1,0 +1,19 @@
+insert into storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types
+)
+values (
+  'publication-cover-images',
+  'publication-cover-images',
+  true,
+  5242880,
+  array['image/jpeg', 'image/png', 'image/webp']
+)
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;

--- a/supabase/migrations/20260505113000_add_associate_membership_numbers.sql
+++ b/supabase/migrations/20260505113000_add_associate_membership_numbers.sql
@@ -1,0 +1,153 @@
+alter table aajf.associate_profiles
+  add column if not exists membership_number text;
+
+alter table aajf.associate_dependents
+  add column if not exists membership_number text;
+
+create sequence if not exists aajf.associate_membership_number_seq
+  start with 1
+  increment by 1
+  minvalue 1;
+
+create sequence if not exists aajf.associate_dependent_membership_number_seq
+  start with 1
+  increment by 1
+  minvalue 1;
+
+create or replace function app_private.next_associate_membership_number()
+returns text
+language plpgsql
+as $$
+declare
+  next_number bigint;
+begin
+  next_number := nextval('aajf.associate_membership_number_seq');
+  return lpad(next_number::text, 6, '0');
+end;
+$$;
+
+create or replace function app_private.next_associate_dependent_membership_number()
+returns text
+language plpgsql
+as $$
+declare
+  next_number bigint;
+begin
+  next_number := nextval('aajf.associate_dependent_membership_number_seq');
+  return 'D' || lpad(next_number::text, 6, '0');
+end;
+$$;
+
+revoke all on function app_private.next_associate_membership_number()
+  from public, anon, authenticated;
+
+revoke all on function app_private.next_associate_dependent_membership_number()
+  from public, anon, authenticated;
+
+create or replace function aajf.assign_associate_membership_number()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.membership_number is null or btrim(new.membership_number) = '' then
+    new.membership_number := app_private.next_associate_membership_number();
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function aajf.assign_associate_dependent_membership_number()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.membership_number is null or btrim(new.membership_number) = '' then
+    new.membership_number := app_private.next_associate_dependent_membership_number();
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists set_associate_membership_number
+  on aajf.associate_profiles;
+
+create trigger set_associate_membership_number
+before insert on aajf.associate_profiles
+for each row execute function aajf.assign_associate_membership_number();
+
+drop trigger if exists set_associate_dependent_membership_number
+  on aajf.associate_dependents;
+
+create trigger set_associate_dependent_membership_number
+before insert on aajf.associate_dependents
+for each row execute function aajf.assign_associate_dependent_membership_number();
+
+select setval(
+  'aajf.associate_membership_number_seq',
+  coalesce(
+    (
+      select max(membership_number::bigint)
+      from aajf.associate_profiles
+      where membership_number ~ '^\d{6}$'
+    ),
+    1
+  ),
+  exists (
+    select 1
+    from aajf.associate_profiles
+    where membership_number ~ '^\d{6}$'
+  )
+);
+
+with ordered_profiles as (
+  select id
+  from aajf.associate_profiles
+  where membership_number is null or btrim(membership_number) = ''
+  order by created_at, id
+)
+update aajf.associate_profiles as profile
+set membership_number = app_private.next_associate_membership_number()
+from ordered_profiles
+where profile.id = ordered_profiles.id;
+
+select setval(
+  'aajf.associate_dependent_membership_number_seq',
+  coalesce(
+    (
+      select max(substring(membership_number from 2)::bigint)
+      from aajf.associate_dependents
+      where membership_number ~ '^D\d{6}$'
+    ),
+    1
+  ),
+  exists (
+    select 1
+    from aajf.associate_dependents
+    where membership_number ~ '^D\d{6}$'
+  )
+);
+
+with ordered_dependents as (
+  select id
+  from aajf.associate_dependents
+  where membership_number is null or btrim(membership_number) = ''
+  order by created_at, id
+)
+update aajf.associate_dependents as dependent
+set membership_number = app_private.next_associate_dependent_membership_number()
+from ordered_dependents
+where dependent.id = ordered_dependents.id;
+
+alter table aajf.associate_profiles
+  alter column membership_number set not null;
+
+alter table aajf.associate_dependents
+  alter column membership_number set not null;
+
+create unique index if not exists associate_profiles_membership_number_key
+  on aajf.associate_profiles (membership_number);
+
+create unique index if not exists associate_dependents_membership_number_key
+  on aajf.associate_dependents (membership_number);

--- a/supabase/migrations/20260505121000_fix_membership_number_function_permissions.sql
+++ b/supabase/migrations/20260505121000_fix_membership_number_function_permissions.sql
@@ -1,0 +1,69 @@
+create or replace function app_private.next_associate_membership_number()
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  next_number bigint;
+begin
+  next_number := nextval('aajf.associate_membership_number_seq');
+  return lpad(next_number::text, 6, '0');
+end;
+$$;
+
+create or replace function app_private.next_associate_dependent_membership_number()
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  next_number bigint;
+begin
+  next_number := nextval('aajf.associate_dependent_membership_number_seq');
+  return 'D' || lpad(next_number::text, 6, '0');
+end;
+$$;
+
+revoke all on function app_private.next_associate_membership_number()
+  from public, anon, authenticated;
+
+revoke all on function app_private.next_associate_dependent_membership_number()
+  from public, anon, authenticated;
+
+create or replace function aajf.assign_associate_membership_number()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.membership_number is null or btrim(new.membership_number) = '' then
+    new.membership_number := app_private.next_associate_membership_number();
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function aajf.assign_associate_dependent_membership_number()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.membership_number is null or btrim(new.membership_number) = '' then
+    new.membership_number := app_private.next_associate_dependent_membership_number();
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function aajf.assign_associate_membership_number()
+  from public, anon, authenticated;
+
+revoke all on function aajf.assign_associate_dependent_membership_number()
+  from public, anon, authenticated;


### PR DESCRIPTION
## Resumo

- adiciona matrícula automática para associados e dependentes
- define sequências separadas para os dois tipos de cadastro
- persiste matrícula no perfil do associado e no cadastro de dependentes
- evita que dependentes percam identidade ao salvar a ficha novamente
- exibe matrícula na área do associado
- exibe matrícula na gestão administrativa de associados
- usa a matrícula como identificador principal na carteirinha quando disponível
- corrige permissões das funções de geração automática no Supabase

## Validação funcional

- [x] associado passa a ter matrícula própria
- [x] dependente passa a ter matrícula própria
- [x] matrículas de associado e dependente usam formatos distintos
- [x] matrícula é exibida como campo não editável
- [x] dependente não perde identidade ao salvar a ficha
- [x] admin consegue visualizar matrícula do associado
- [x] admin consegue visualizar matrícula dos dependentes
- [ ] validar aplicação das migrations no Supabase
- [ ] validar criação de novo dependente após a migration de permissões
- [ ] validar backfill completo dos registros antigos

## Migrations incluídas

- `20260505113000_add_associate_membership_numbers.sql`
- `20260505121000_fix_membership_number_function_permissions.sql`

## Observações

- a matrícula do associado usa sequência numérica simples, como `000001`
- a matrícula do dependente usa prefixo próprio, como `D000001`
- a geração acontece no backend/banco, não na interface
- a matrícula não deve ser editável manualmente
- a correção final de permissões foi necessária para que a geração automática funcionasse durante o salvamento da ficha autenticada

## Issue

- `#21`
