### PR TITLE
feat: adiciona exportação de associados em excel e pdf

### DIFF
--- a/docs/associate-export-spec.md
+++ b/docs/associate-export-spec.md
@@ -1,0 +1,293 @@
+# Especificação inicial de exportação de associados
+
+Issue de origem: [#29 Exportar em PDF e EXCEL](https://github.com/thalescampelodac/landing-page-aajf/issues/29)
+
+## Objetivo
+
+Definir como a administração poderá exportar os dados dos associados em:
+
+- `Excel`
+- `PDF`
+
+O foco desta issue é transformar a listagem administrativa de associados em uma
+saída utilizável fora do sistema, tanto para operação interna quanto para
+compartilhamento institucional.
+
+## Contexto atual
+
+Hoje o módulo `/admin/associados` já possui:
+
+- listagem administrativa dos associados
+- filtros por busca, status e categoria
+- paginação
+- modal de leitura com os dados completos do associado
+
+Ainda falta transformar esses dados em arquivos exportáveis para uso
+administrativo real.
+
+## Resultado esperado
+
+Ao final da issue, a administração deve conseguir:
+
+1. exportar a listagem de associados para `Excel`
+2. exportar a listagem de associados para `PDF`
+3. usar os filtros ativos como base da exportação
+4. levar no arquivo os principais dados do associado
+5. gerar uma saída legível também para dependentes
+
+## Direção de produto
+
+A exportação deve seguir dois objetivos diferentes:
+
+### Excel
+
+Usado para:
+
+- conferência administrativa
+- organização interna
+- manipulação posterior dos dados
+- importação em rotinas paralelas
+
+### PDF
+
+Usado para:
+
+- compartilhamento institucional
+- impressão
+- relatório visual consolidado
+
+## Regra principal de escopo
+
+As exportações são funcionalidades próprias do módulo administrativo.
+
+Isso significa que:
+
+- não dependem do grid atual
+- não dependem da paginação
+- não são “exportação da tabela da tela”
+- partem diretamente dos dados persistidos no banco
+
+A tela administrativa pode futuramente oferecer parâmetros para exportação, mas
+o arquivo gerado deve ser tratado como uma representação estruturada do domínio
+de associados, e não como um espelho visual da listagem.
+
+## Exportação em Excel
+
+### Objetivo
+
+Gerar uma planilha operacional, limpa e manipulável.
+
+### Formato sugerido
+
+- arquivo `.xlsx`
+- uma única aba
+- cada linha representa um registro exportado
+- a hierarquia entre associado e dependentes deve aparecer na própria planilha
+
+### Colunas mínimas recomendadas
+
+- tipo de registro
+- matrícula do associado
+- matrícula do associado responsável
+- matrícula do próprio registro
+- nome completo
+- email
+- categoria
+- status
+- telefone
+- CPF
+- RG
+- data de nascimento
+- naturalidade
+- CEP
+- rua
+- número
+- complemento
+- bairro
+- cidade
+- UF
+- observação
+- data de concessão do vínculo
+
+### Estrutura hierárquica no Excel
+
+O Excel deve usar uma única aba com hierarquia explícita:
+
+- primeiro vem a linha do associado
+- logo abaixo vêm as linhas de seus dependentes
+
+Para deixar isso claro, a planilha deve ter pelo menos:
+
+- coluna `tipo_registro`
+  - `associado`
+  - `dependente`
+- coluna `matricula_associado_responsavel`
+- coluna `matricula_registro`
+
+Regra sugerida:
+
+- quando a linha for do associado, `matricula_registro` e
+  `matricula_associado_responsavel` podem coincidir
+- quando a linha for de dependente, `matricula_registro` é a matrícula do
+  dependente e `matricula_associado_responsavel` aponta para o associado
+
+### Dependentes no Excel
+
+Os dependentes não devem ir para aba separada.
+
+Eles aparecem:
+
+- na mesma aba
+- em linhas próprias
+- logo abaixo do associado responsável
+
+Minha recomendação é que a exportação use também diferenciação visual:
+
+- associado com linha principal
+- dependente com estilo secundário ou recuo visual
+
+Assim a planilha continua legível para operação humana sem perder a relação
+entre os registros.
+
+## Exportação em PDF
+
+### Objetivo
+
+Gerar um relatório visual e compartilhável da listagem atual.
+
+### Formato sugerido
+
+- arquivo `.pdf`
+- cabeçalho institucional da associação
+- título do relatório
+- data e hora da exportação
+- resumo dos filtros aplicados
+
+### Conteúdo sugerido
+
+O PDF deve seguir a mesma fonte de verdade do banco e a mesma lógica de
+hierarquia do domínio.
+
+Ele não precisa imitar o grid nem a planilha, mas deve refletir:
+
+- associado como registro principal
+- dependentes abaixo do associado responsável
+
+Sugestão de saída resumida por associado:
+
+- matrícula
+- nome
+- email
+- categoria
+- status
+- telefone
+- dependentes vinculados
+
+### Dependentes no PDF
+
+Os dependentes devem aparecer vinculados ao associado responsável.
+
+Minha recomendação:
+
+- em vez de exibir só a contagem, listar os dependentes abaixo do associado
+- manter a apresentação mais compacta do que no Excel
+
+Assim o PDF continua institucional, mas preserva a relação entre os registros.
+
+## Nome dos arquivos
+
+Sugestão:
+
+### Excel
+
+- `associados-YYYY-MM-DD.xlsx`
+
+### PDF
+
+- `associados-YYYY-MM-DD.pdf`
+
+## Regras de negócio
+
+- apenas usuários administrativos autorizados podem exportar
+- a exportação usa somente os dados já autorizados para a administração
+- a matrícula deve aparecer na exportação
+- dependentes também devem levar matrícula própria
+- a exportação não deve alterar dados do banco
+- a exportação deve refletir o estado atual dos dados persistidos
+- a exportação deve partir dos registros persistidos, não da renderização da
+  tela
+
+## Regras de UX
+
+- os botões de exportação devem ficar no topo da área de listagem
+- os rótulos devem ser simples:
+  - `Exportar Excel`
+  - `Exportar PDF`
+- se a exportação futuramente permitir recorte por parâmetro, o estado vazio
+  deve ser tratado com mensagem amigável
+
+## Regras técnicas sugeridas
+
+### Excel
+
+- geração no servidor
+- retorno como download direto
+- arquivo montado a partir dos dados persistidos do banco
+- hierarquia de associado e dependentes construída durante a exportação
+
+### PDF
+
+- geração no servidor
+- layout simples e institucional
+- evitar depender de impressão de HTML bruto
+- composição baseada nos dados persistidos do banco
+
+## Perguntas já respondidas nesta especificação
+
+1. A exportação deve respeitar filtros ativos da tela?
+
+Não como regra principal.
+
+Ela é uma funcionalidade própria e desacoplada do grid.
+
+2. O Excel deve conter todos os dados?
+
+Sim, em uma única aba com hierarquia explícita entre associado e dependentes.
+
+3. O PDF deve ser completo ou resumido?
+
+Resumido.
+
+4. Dependentes entram na exportação?
+
+Sim, preservando o vínculo com o associado responsável.
+
+## Critérios de aceite propostos
+
+- a tela `/admin/associados` oferece botão de exportar `Excel`
+- a tela `/admin/associados` oferece botão de exportar `PDF`
+- o Excel exporta associados e dependentes em uma única aba
+- o PDF exporta associados e dependentes em formato legível e institucional
+- as matrículas aparecem na exportação
+- a exportação não exige navegação extra fora do módulo
+
+## Fora de escopo por enquanto
+
+Esta issue ainda não precisa incluir:
+
+- envio automático por email
+- templates múltiplos de PDF
+- personalização de colunas pelo usuário
+- exportação de carteirinhas
+- assinatura digital de relatório
+
+## Próximo passo sugerido
+
+Depois de alinhar esta especificação na issue, a implementação pode ser dividida
+em duas etapas:
+
+1. exportação `Excel`
+2. exportação `PDF`
+
+Assim a gente fecha primeiro a saída operacional mais útil e depois entra na
+camada de apresentação institucional.

--- a/src/app/admin/associados/export/excel/route.test.ts
+++ b/src/app/admin/associados/export/excel/route.test.ts
@@ -1,0 +1,100 @@
+import { GET } from "@/app/admin/associados/export/excel/route";
+
+const { buildAssociateExcelWorkbookMock, getAdminAssociateExportRowsMock } =
+  vi.hoisted(() => ({
+    buildAssociateExcelWorkbookMock: vi.fn(),
+    getAdminAssociateExportRowsMock: vi.fn(),
+  }));
+
+vi.mock("@/lib/supabase/admin-associates", () => ({
+  getAdminAssociateExportRows: getAdminAssociateExportRowsMock,
+}));
+
+vi.mock("@/lib/associate-export-excel", () => ({
+  buildAssociateExcelWorkbook: buildAssociateExcelWorkbookMock,
+}));
+
+describe("admin associados excel export route", () => {
+  beforeEach(() => {
+    buildAssociateExcelWorkbookMock.mockReset();
+    getAdminAssociateExportRowsMock.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-05T15:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retorna 401 quando o usuario nao esta autenticado", async () => {
+    getAdminAssociateExportRowsMock.mockResolvedValue({
+      access: { status: "unauthenticated" },
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toMatch(/faça login/i);
+  });
+
+  it("retorna 403 quando o usuario nao tem permissao administrativa", async () => {
+    getAdminAssociateExportRowsMock.mockResolvedValue({
+      access: { status: "denied", email: "pessoa@example.com" },
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toMatch(/administradores autorizados/i);
+  });
+
+  it("retorna workbook excel com headers de download para admin autorizado", async () => {
+    getAdminAssociateExportRowsMock.mockResolvedValue({
+      access: {
+        email: "admin@example.com",
+        profileId: "profile-1",
+        role: "super_admin",
+        status: "authorized",
+      },
+      rows: [
+        {
+          addressCity: "Juiz de Fora",
+          addressComplement: "",
+          addressNeighborhood: "Centro",
+          addressNumber: "100",
+          addressState: "MG",
+          addressStreet: "Rua Principal",
+          associateResponsibleMembershipNumber: "000001",
+          associateResponsibleName: "Associado Exemplo",
+          birthDate: "1982-07-19",
+          category: "Heimweh",
+          cpf: "057.807.496-63",
+          email: "associado@example.com",
+          grantedAt: "2026-05-05T12:00:00.000Z",
+          hasPhoto: "Sim",
+          membershipNumber: "000001",
+          name: "Associado Exemplo",
+          nationality: "Brasileira",
+          observation: "",
+          phone: "(32) 99999-0000",
+          rg: "8056162",
+          status: "active",
+          termAccepted: "Sim",
+          type: "associado",
+          zipCode: "36021-690",
+        },
+      ],
+    });
+    buildAssociateExcelWorkbookMock.mockReturnValue("<Workbook />");
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(buildAssociateExcelWorkbookMock).toHaveBeenCalledTimes(1);
+    expect(response.headers.get("Content-Type")).toContain("application/vnd.ms-excel");
+    expect(response.headers.get("Content-Disposition")).toContain(
+      'attachment; filename="associados-2026-05-05.xls"',
+    );
+    await expect(response.text()).resolves.toBe("<Workbook />");
+  });
+});

--- a/src/app/admin/associados/export/excel/route.ts
+++ b/src/app/admin/associados/export/excel/route.ts
@@ -1,0 +1,54 @@
+import { getAdminAssociateExportRows } from "@/lib/supabase/admin-associates";
+import { buildAssociateExcelWorkbook } from "@/lib/associate-export-excel";
+
+export const dynamic = "force-dynamic";
+
+function hasAuthorizedRows(
+  result: Awaited<ReturnType<typeof getAdminAssociateExportRows>>,
+): result is Extract<
+  Awaited<ReturnType<typeof getAdminAssociateExportRows>>,
+  { access: { status: "authorized" } }
+> {
+  return result.access.status === "authorized";
+}
+
+export async function GET() {
+  const result = await getAdminAssociateExportRows();
+
+  if (result.access.status === "unconfigured") {
+    return new Response("Supabase ainda não está configurado neste ambiente.", {
+      status: 503,
+    });
+  }
+
+  if (result.access.status === "unauthenticated") {
+    return new Response("Faça login para exportar os associados.", {
+      status: 401,
+    });
+  }
+
+  if (result.access.status === "denied") {
+    return new Response("Apenas administradores autorizados podem exportar os associados.", {
+      status: 403,
+    });
+  }
+
+  if (!hasAuthorizedRows(result)) {
+    return new Response("Não foi possível preparar a exportação dos associados.", {
+      status: 500,
+    });
+  }
+
+  const authorizedResult = result;
+  const workbook = buildAssociateExcelWorkbook(authorizedResult.rows);
+  const filename = `associados-${new Date().toISOString().slice(0, 10)}.xls`;
+
+  return new Response(workbook, {
+    headers: {
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Type": "application/vnd.ms-excel; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+    status: 200,
+  });
+}

--- a/src/app/admin/associados/export/pdf/route.test.ts
+++ b/src/app/admin/associados/export/pdf/route.test.ts
@@ -1,0 +1,104 @@
+import { GET } from "@/app/admin/associados/export/pdf/route";
+
+const { buildAssociatePdfDocumentMock, getAdminAssociateExportRowsMock } =
+  vi.hoisted(() => ({
+    buildAssociatePdfDocumentMock: vi.fn(),
+    getAdminAssociateExportRowsMock: vi.fn(),
+  }));
+
+vi.mock("@/lib/supabase/admin-associates", () => ({
+  getAdminAssociateExportRows: getAdminAssociateExportRowsMock,
+}));
+
+vi.mock("@/lib/associate-export-pdf", () => ({
+  buildAssociatePdfDocument: buildAssociatePdfDocumentMock,
+}));
+
+describe("admin associados pdf export route", () => {
+  beforeEach(() => {
+    buildAssociatePdfDocumentMock.mockReset();
+    getAdminAssociateExportRowsMock.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-05T15:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retorna 401 quando o usuario nao esta autenticado", async () => {
+    getAdminAssociateExportRowsMock.mockResolvedValue({
+      access: { status: "unauthenticated" },
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toMatch(/faça login/i);
+  });
+
+  it("retorna 403 quando o usuario nao tem permissao administrativa", async () => {
+    getAdminAssociateExportRowsMock.mockResolvedValue({
+      access: { status: "denied", email: "pessoa@example.com" },
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toMatch(/administradores autorizados/i);
+  });
+
+  it("retorna documento pdf com headers de download para admin autorizado", async () => {
+    getAdminAssociateExportRowsMock.mockResolvedValue({
+      access: {
+        email: "admin@example.com",
+        profileId: "profile-1",
+        role: "super_admin",
+        status: "authorized",
+      },
+      rows: [
+        {
+          addressCity: "Juiz de Fora",
+          addressComplement: "",
+          addressNeighborhood: "Centro",
+          addressNumber: "100",
+          addressState: "MG",
+          addressStreet: "Rua Principal",
+          associateResponsibleMembershipNumber: "000001",
+          associateResponsibleName: "Associado Exemplo",
+          birthDate: "1982-07-19",
+          category: "Heimweh",
+          cpf: "057.807.496-63",
+          email: "associado@example.com",
+          grantedAt: "2026-05-05T12:00:00.000Z",
+          hasPhoto: "Sim",
+          membershipNumber: "000001",
+          name: "Associado Exemplo",
+          nationality: "Brasileira",
+          observation: "",
+          phone: "(32) 99999-0000",
+          rg: "8056162",
+          status: "active",
+          termAccepted: "Sim",
+          type: "associado",
+          zipCode: "36021-690",
+        },
+      ],
+    });
+    buildAssociatePdfDocumentMock.mockReturnValue(
+      new Uint8Array([37, 80, 68, 70]),
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(buildAssociatePdfDocumentMock).toHaveBeenCalledTimes(1);
+    expect(response.headers.get("Content-Type")).toContain("application/pdf");
+    expect(response.headers.get("Content-Disposition")).toContain(
+      'attachment; filename="associados-2026-05-05.pdf"',
+    );
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      new Uint8Array([37, 80, 68, 70]),
+    );
+  });
+});

--- a/src/app/admin/associados/export/pdf/route.ts
+++ b/src/app/admin/associados/export/pdf/route.ts
@@ -1,0 +1,53 @@
+import { getAdminAssociateExportRows } from "@/lib/supabase/admin-associates";
+import { buildAssociatePdfDocument } from "@/lib/associate-export-pdf";
+
+export const dynamic = "force-dynamic";
+
+function hasAuthorizedRows(
+  result: Awaited<ReturnType<typeof getAdminAssociateExportRows>>,
+): result is Extract<
+  Awaited<ReturnType<typeof getAdminAssociateExportRows>>,
+  { access: { status: "authorized" } }
+> {
+  return result.access.status === "authorized";
+}
+
+export async function GET() {
+  const result = await getAdminAssociateExportRows();
+
+  if (result.access.status === "unconfigured") {
+    return new Response("Supabase ainda não está configurado neste ambiente.", {
+      status: 503,
+    });
+  }
+
+  if (result.access.status === "unauthenticated") {
+    return new Response("Faça login para exportar os associados.", {
+      status: 401,
+    });
+  }
+
+  if (result.access.status === "denied") {
+    return new Response("Apenas administradores autorizados podem exportar os associados.", {
+      status: 403,
+    });
+  }
+
+  if (!hasAuthorizedRows(result)) {
+    return new Response("Não foi possível preparar a exportação dos associados.", {
+      status: 500,
+    });
+  }
+
+  const document = buildAssociatePdfDocument(result.rows);
+  const filename = `associados-${new Date().toISOString().slice(0, 10)}.pdf`;
+
+  return new Response(document, {
+    headers: {
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Type": "application/pdf",
+      "Cache-Control": "no-store",
+    },
+    status: 200,
+  });
+}

--- a/src/components/admin-associates-manager.tsx
+++ b/src/components/admin-associates-manager.tsx
@@ -59,7 +59,23 @@ export function AdminAssociatesManager({
     <div className="grid gap-6">
       <section className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(20rem,0.95fr)]">
         <article className="rounded-[1.6rem] border border-[rgba(23,61,46,0.12)] bg-white/72 p-6">
-          <p className="section-eyebrow">Associados atuais</p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <p className="section-eyebrow">Associados atuais</p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <a
+                className="secondary-button"
+                href="/admin/associados/export/excel"
+              >
+                Exportar Excel
+              </a>
+              <a
+                className="secondary-button"
+                href="/admin/associados/export/pdf"
+              >
+                Exportar PDF
+              </a>
+            </div>
+          </div>
           <div className="mt-4 grid gap-4">
             <div className="grid gap-4 rounded-[1.4rem] border border-[rgba(23,54,45,0.1)] bg-[rgba(255,250,243,0.72)] p-4 lg:grid-cols-3">
               <label className="form-field">

--- a/src/lib/associate-export-excel.test.ts
+++ b/src/lib/associate-export-excel.test.ts
@@ -1,0 +1,79 @@
+import { buildAssociateExcelWorkbook } from "@/lib/associate-export-excel";
+import type { AdminAssociateExportRow } from "@/lib/supabase/admin-associates";
+
+describe("associate export excel", () => {
+  it("gera workbook com hierarquia de associado e dependente na mesma aba", () => {
+    const rows: AdminAssociateExportRow[] = [
+      {
+        addressCity: "Juiz de Fora",
+        addressComplement: "Apto 101",
+        addressNeighborhood: "Centro",
+        addressNumber: "100",
+        addressState: "MG",
+        addressStreet: "Rua Principal",
+        associateResponsibleMembershipNumber: "000001",
+        associateResponsibleName: "Associado Exemplo",
+        birthDate: "1982-07-19",
+        category: "Heimweh",
+        cpf: "057.807.496-63",
+        email: "associado@example.com",
+        grantedAt: "2026-05-05T12:00:00.000Z",
+        hasPhoto: "Sim",
+        membershipNumber: "000001",
+        name: "Associado Exemplo",
+        nationality: "Brasileira",
+        observation: "Observação <importante>",
+        phone: "(32) 99999-0000",
+        rg: "8056162",
+        status: "active",
+        termAccepted: "Sim",
+        type: "associado",
+        zipCode: "36021-690",
+      },
+      {
+        addressCity: "",
+        addressComplement: "",
+        addressNeighborhood: "",
+        addressNumber: "",
+        addressState: "",
+        addressStreet: "",
+        associateResponsibleMembershipNumber: "000001",
+        associateResponsibleName: "Associado Exemplo",
+        birthDate: "2013-10-18",
+        category: "Grosse Kinder",
+        cpf: "057.807.496-63",
+        email: "",
+        grantedAt: "2026-05-05T12:00:00.000Z",
+        hasPhoto: "Nao",
+        membershipNumber: "D000001",
+        name: "Dependente Exemplo",
+        nationality: "Brasileira",
+        observation: "",
+        phone: "",
+        rg: "8056162",
+        status: "active",
+        termAccepted: "",
+        type: "dependente",
+        zipCode: "",
+      },
+    ];
+
+    const workbook = buildAssociateExcelWorkbook(rows);
+
+    expect(workbook).toContain('<?xml version="1.0"?>');
+    expect(workbook).toContain('<Worksheet ss:Name="Associados">');
+    expect(workbook).toContain("tipo_registro");
+    expect(workbook).toContain("matricula_registro");
+    expect(workbook).toContain("matricula_associado_responsavel");
+    expect(workbook).toContain(">associado<");
+    expect(workbook).toContain(">dependente<");
+    expect(workbook).toContain(">000001<");
+    expect(workbook).toContain(">D000001<");
+    expect(workbook).toContain("Associado Exemplo");
+    expect(workbook).toContain("Dependente Exemplo");
+    expect(workbook).toContain("Grosse Kinder");
+    expect(workbook).toContain("Observação &lt;importante&gt;");
+    expect(workbook).toContain('ss:StyleID="AssociateRow"');
+    expect(workbook).toContain('ss:StyleID="DependentRow"');
+  });
+});

--- a/src/lib/associate-export-excel.ts
+++ b/src/lib/associate-export-excel.ts
@@ -1,0 +1,138 @@
+import type { AdminAssociateExportRow } from "@/lib/supabase/admin-associates";
+
+const EXCEL_HEADERS: Array<{
+  key: keyof AdminAssociateExportRow;
+  label: string;
+  width: number;
+}> = [
+  { key: "type", label: "tipo_registro", width: 16 },
+  { key: "membershipNumber", label: "matricula_registro", width: 18 },
+  {
+    key: "associateResponsibleMembershipNumber",
+    label: "matricula_associado_responsavel",
+    width: 26,
+  },
+  {
+    key: "associateResponsibleName",
+    label: "nome_associado_responsavel",
+    width: 34,
+  },
+  { key: "name", label: "nome_completo", width: 34 },
+  { key: "email", label: "email", width: 34 },
+  { key: "category", label: "categoria", width: 18 },
+  { key: "status", label: "status_vinculo", width: 16 },
+  { key: "phone", label: "telefone", width: 18 },
+  { key: "cpf", label: "cpf", width: 18 },
+  { key: "rg", label: "rg", width: 18 },
+  { key: "birthDate", label: "data_nascimento", width: 18 },
+  { key: "nationality", label: "nacionalidade", width: 18 },
+  { key: "zipCode", label: "cep", width: 14 },
+  { key: "addressStreet", label: "rua", width: 28 },
+  { key: "addressNumber", label: "numero", width: 12 },
+  { key: "addressComplement", label: "complemento", width: 18 },
+  { key: "addressNeighborhood", label: "bairro", width: 22 },
+  { key: "addressCity", label: "cidade", width: 22 },
+  { key: "addressState", label: "uf", width: 10 },
+  { key: "observation", label: "observacao", width: 32 },
+  { key: "termAccepted", label: "termo_aceito", width: 14 },
+  { key: "hasPhoto", label: "possui_foto", width: 14 },
+  { key: "grantedAt", label: "data_concessao", width: 22 },
+];
+
+export function buildAssociateExcelWorkbook(rows: AdminAssociateExportRow[]) {
+  const headerRow = xmlRow(
+    EXCEL_HEADERS.map((column) =>
+      xmlCell(column.label, "Header"),
+    ),
+  );
+
+  const bodyRows = rows
+    .map((row) =>
+      xmlRow(
+        EXCEL_HEADERS.map((column) =>
+          xmlCell(
+            formatCellValue(row[column.key]),
+            row.type === "associado" ? "AssociateRow" : "DependentRow",
+          ),
+        ),
+      ),
+    )
+    .join("");
+
+  const columns = EXCEL_HEADERS.map(
+    (column) => `<Column ss:AutoFitWidth="0" ss:Width="${column.width * 6.4}"/>`,
+  ).join("");
+
+  return `<?xml version="1.0"?>
+<?mso-application progid="Excel.Sheet"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:html="http://www.w3.org/TR/REC-html40">
+  <Styles>
+    <Style ss:ID="Default" ss:Name="Normal">
+      <Alignment ss:Vertical="Top" ss:WrapText="1"/>
+      <Font ss:FontName="Calibri" ss:Size="11" ss:Color="#17362d"/>
+      <Interior ss:Color="#fffaf3" ss:Pattern="Solid"/>
+      <Borders>
+        <Border ss:Position="Bottom" ss:LineStyle="Continuous" ss:Weight="1" ss:Color="#d8d4ca"/>
+        <Border ss:Position="Left" ss:LineStyle="Continuous" ss:Weight="1" ss:Color="#d8d4ca"/>
+        <Border ss:Position="Right" ss:LineStyle="Continuous" ss:Weight="1" ss:Color="#d8d4ca"/>
+        <Border ss:Position="Top" ss:LineStyle="Continuous" ss:Weight="1" ss:Color="#d8d4ca"/>
+      </Borders>
+    </Style>
+    <Style ss:ID="Header">
+      <Font ss:FontName="Calibri" ss:Size="11" ss:Bold="1" ss:Color="#9a1f2b"/>
+      <Interior ss:Color="#f7f1e7" ss:Pattern="Solid"/>
+    </Style>
+    <Style ss:ID="AssociateRow">
+      <Font ss:FontName="Calibri" ss:Size="11" ss:Bold="1" ss:Color="#17362d"/>
+      <Interior ss:Color="#fffdf8" ss:Pattern="Solid"/>
+    </Style>
+    <Style ss:ID="DependentRow">
+      <Font ss:FontName="Calibri" ss:Size="11" ss:Color="#42564f"/>
+      <Interior ss:Color="#f9f4ec" ss:Pattern="Solid"/>
+    </Style>
+  </Styles>
+  <Worksheet ss:Name="Associados">
+    <Table>
+      ${columns}
+      ${headerRow}
+      ${bodyRows}
+    </Table>
+    <WorksheetOptions xmlns="urn:schemas-microsoft-com:office:excel">
+      <FreezePanes/>
+      <FrozenNoSplit/>
+      <SplitHorizontal>1</SplitHorizontal>
+      <TopRowBottomPane>1</TopRowBottomPane>
+      <Panes>
+        <Pane>
+          <Number>3</Number>
+        </Pane>
+      </Panes>
+    </WorksheetOptions>
+  </Worksheet>
+</Workbook>`;
+}
+
+function xmlRow(cells: string[]) {
+  return `<Row>${cells.join("")}</Row>`;
+}
+
+function xmlCell(value: string, styleId: string) {
+  return `<Cell ss:StyleID="${styleId}"><Data ss:Type="String">${escapeXml(value)}</Data></Cell>`;
+}
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function formatCellValue(value: string) {
+  return value.trim();
+}

--- a/src/lib/associate-export-pdf.test.ts
+++ b/src/lib/associate-export-pdf.test.ts
@@ -1,0 +1,78 @@
+import { buildAssociatePdfDocument } from "@/lib/associate-export-pdf";
+import type { AdminAssociateExportRow } from "@/lib/supabase/admin-associates";
+
+describe("associate export pdf", () => {
+  it("gera documento pdf com hierarquia de associado e dependente", () => {
+    const rows: AdminAssociateExportRow[] = [
+      {
+        addressCity: "Juiz de Fora",
+        addressComplement: "Apto 101",
+        addressNeighborhood: "Centro",
+        addressNumber: "100",
+        addressState: "MG",
+        addressStreet: "Rua Principal",
+        associateResponsibleMembershipNumber: "000001",
+        associateResponsibleName: "Associado Exemplo",
+        birthDate: "1982-07-19",
+        category: "Heimweh",
+        cpf: "057.807.496-63",
+        email: "associado@example.com",
+        grantedAt: "2026-05-05T12:00:00.000Z",
+        hasPhoto: "Sim",
+        membershipNumber: "000001",
+        name: "Associado Exemplo",
+        nationality: "Brasileira",
+        observation: "Observacao importante",
+        phone: "(32) 99999-0000",
+        rg: "8056162",
+        status: "active",
+        termAccepted: "Sim",
+        type: "associado",
+        zipCode: "36021-690",
+      },
+      {
+        addressCity: "",
+        addressComplement: "",
+        addressNeighborhood: "",
+        addressNumber: "",
+        addressState: "",
+        addressStreet: "",
+        associateResponsibleMembershipNumber: "000001",
+        associateResponsibleName: "Associado Exemplo",
+        birthDate: "2013-10-18",
+        category: "Grosse Kinder",
+        cpf: "057.807.496-63",
+        email: "",
+        grantedAt: "2026-05-05T12:00:00.000Z",
+        hasPhoto: "Nao",
+        membershipNumber: "D000001",
+        name: "Dependente Exemplo",
+        nationality: "Brasileira",
+        observation: "",
+        phone: "",
+        rg: "8056162",
+        status: "active",
+        termAccepted: "",
+        type: "dependente",
+        zipCode: "",
+      },
+    ];
+
+    const pdfBytes = buildAssociatePdfDocument(rows);
+    const pdfText = Buffer.from(pdfBytes).toString("latin1");
+
+    expect(pdfBytes.byteLength).toBeGreaterThan(1000);
+    expect(pdfText).toContain("%PDF-1.4");
+    expect(pdfText).toContain("/Type /Catalog");
+    expect(pdfText).toContain("/Type /Page");
+    expect(pdfText).toContain("/Helvetica");
+    expect(pdfText).toContain("AAJF");
+    expect(pdfText).toContain("000001");
+    expect(pdfText).toContain("D000001");
+    expect(pdfText).toContain("Grosse Kinder");
+    expect(pdfText).toContain("/Helvetica-Bold");
+    expect(pdfText).toContain("stream");
+    expect(pdfText).toContain("xref");
+    expect(pdfText).toContain("%%EOF");
+  });
+});

--- a/src/lib/associate-export-pdf.ts
+++ b/src/lib/associate-export-pdf.ts
@@ -1,0 +1,925 @@
+import type { AdminAssociateExportRow } from "@/lib/supabase/admin-associates";
+
+const PAGE_WIDTH = 595;
+const PAGE_HEIGHT = 842;
+const MARGIN_X = 40;
+const FIRST_PAGE_CONTENT_TOP = 594;
+const OTHER_PAGE_CONTENT_TOP = 708;
+const FOOTER_TOP = 44;
+const BOTTOM_LIMIT = 76;
+const CONTENT_WIDTH = PAGE_WIDTH - MARGIN_X * 2;
+const CARD_GAP = 18;
+const CARD_INNER_PADDING = 18;
+const TABLE_HEADER_HEIGHT = 20;
+const TABLE_ROW_HEIGHT = 20;
+const SUMMARY_TOP = 646;
+
+const COLORS = {
+  border: [0.84, 0.83, 0.79] as const,
+  cardBg: [1, 0.985, 0.955] as const,
+  dangerBadge: [0.96, 0.89, 0.9] as const,
+  dangerText: [0.45, 0.09, 0.13] as const,
+  gold: [0.85, 0.69, 0.38] as const,
+  greenBadge: [0.89, 0.95, 0.92] as const,
+  greenText: [0.09, 0.21, 0.18] as const,
+  ink: [0.09, 0.18, 0.14] as const,
+  muted: [0.29, 0.36, 0.34] as const,
+  paper: [1, 0.97, 0.93] as const,
+  tableHeader: [0.97, 0.94, 0.89] as const,
+  warning: [0.58, 0.12, 0.17] as const,
+};
+
+type AssociateGroup = {
+  associate: AdminAssociateExportRow;
+  dependents: AdminAssociateExportRow[];
+};
+
+type AssociateCardChunk = {
+  associate: AdminAssociateExportRow;
+  dependents: AdminAssociateExportRow[];
+  endDependentIndexExclusive: number;
+  hasMoreDependents: boolean;
+  isContinuation: boolean;
+  startDependentIndex: number;
+};
+
+type PageModel = {
+  cards: AssociateCardChunk[];
+  isFirstPage: boolean;
+};
+
+type PdfOp = string;
+type FontKey = "normal" | "bold";
+
+export function buildAssociatePdfDocument(rows: AdminAssociateExportRow[]) {
+  const groups = groupRows(rows);
+  const pages = paginateGroups(groups);
+  const totalAssociates = groups.length;
+  const totalDependents = groups.reduce(
+    (sum, group) => sum + group.dependents.length,
+    0,
+  );
+  const exportedAt = new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date());
+
+  const pageEntries: Array<{ contentObjectId: number; pageObjectId: number }> = [];
+  const objects: Array<{ id: number; body: string }> = [];
+  let nextObjectId = 3;
+
+  for (const [pageIndex, page] of pages.entries()) {
+    const pageObjectId = nextObjectId++;
+    const contentObjectId = nextObjectId++;
+    pageEntries.push({ contentObjectId, pageObjectId });
+
+    const contentStream = buildPageContentStream({
+      exportedAt,
+      page,
+      pageIndex: pageIndex + 1,
+      totalAssociates,
+      totalDependents,
+      totalPages: pages.length,
+    });
+
+    objects.push({
+      body: `<< /Length ${latin1ByteLength(contentStream)} >>\nstream\n${contentStream}\nendstream`,
+      id: contentObjectId,
+    });
+    objects.push({
+      body: `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${PAGE_WIDTH} ${PAGE_HEIGHT}] /Resources << /Font << /F1 ${nextObjectId} 0 R /F2 ${nextObjectId + 1} 0 R >> >> /Contents ${contentObjectId} 0 R >>`,
+      id: pageObjectId,
+    });
+  }
+
+  const normalFontId = nextObjectId++;
+  const boldFontId = nextObjectId++;
+  objects.push({
+    body: "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+    id: normalFontId,
+  });
+  objects.push({
+    body: "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>",
+    id: boldFontId,
+  });
+
+  const pagesKids = pageEntries.map((entry) => `${entry.pageObjectId} 0 R`).join(" ");
+  objects.unshift(
+    {
+      body: `<< /Type /Pages /Kids [${pagesKids}] /Count ${pageEntries.length} >>`,
+      id: 2,
+    },
+    { body: "<< /Type /Catalog /Pages 2 0 R >>", id: 1 },
+  );
+
+  const orderedObjects = objects.sort((a, b) => a.id - b.id);
+  const header = "%PDF-1.4\n%âãÏÓ\n";
+  const parts: string[] = [header];
+  const offsets: number[] = [0];
+  let currentOffset = latin1ByteLength(header);
+
+  for (const object of orderedObjects) {
+    offsets[object.id] = currentOffset;
+    const objectString = `${object.id} 0 obj\n${object.body}\nendobj\n`;
+    parts.push(objectString);
+    currentOffset += latin1ByteLength(objectString);
+  }
+
+  const xrefOffset = currentOffset;
+  const totalObjects = orderedObjects.length + 1;
+  let xref = `xref\n0 ${totalObjects}\n0000000000 65535 f \n`;
+
+  for (let index = 1; index < totalObjects; index += 1) {
+    xref += `${String(offsets[index]).padStart(10, "0")} 00000 n \n`;
+  }
+
+  const trailer = `trailer\n<< /Size ${totalObjects} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+  parts.push(xref, trailer);
+
+  return encodeLatin1(parts.join(""));
+}
+
+function buildPageContentStream({
+  exportedAt,
+  page,
+  pageIndex,
+  totalAssociates,
+  totalDependents,
+  totalPages,
+}: {
+  exportedAt: string;
+  page: PageModel;
+  pageIndex: number;
+  totalAssociates: number;
+  totalDependents: number;
+  totalPages: number;
+}) {
+  const ops: PdfOp[] = [];
+  drawPageHeader(ops, exportedAt);
+  drawPageFooter(ops, exportedAt, pageIndex, totalPages);
+
+  if (page.isFirstPage) {
+    drawSummaryCards(ops, exportedAt, totalAssociates, totalDependents);
+  }
+
+  let currentTop = page.isFirstPage ? FIRST_PAGE_CONTENT_TOP : OTHER_PAGE_CONTENT_TOP;
+
+  for (const card of page.cards) {
+    const cardHeight = measureCardHeight(card);
+    drawAssociateCard(ops, card, currentTop, cardHeight);
+    currentTop -= cardHeight + CARD_GAP;
+  }
+
+  return ops.join("\n");
+}
+
+function drawPageHeader(ops: PdfOp[], exportedAt: string) {
+  drawCircle(ops, 64, 760, 20, {
+    fill: COLORS.greenText,
+  });
+  drawText(ops, "AAJF", 47, 755, {
+    color: COLORS.paper,
+    font: "bold",
+    size: 13.5,
+  });
+
+  drawText(ops, "Associação Alemã de Juiz de Fora", 102, 776, {
+    color: COLORS.ink,
+    font: "bold",
+    size: 16.5,
+  });
+  drawText(ops, "Relatório de Associados e Dependentes", 102, 753, {
+    color: COLORS.gold,
+    font: "bold",
+    size: 11.5,
+  });
+  drawTextRight(ops, `Exportado em ${exportedAt}`, PAGE_WIDTH - MARGIN_X, 776, {
+    color: COLORS.muted,
+    size: 9.5,
+  });
+  drawTextRight(ops, "Documento interno - contém dados pessoais.", PAGE_WIDTH - MARGIN_X, 756, {
+    color: COLORS.warning,
+    font: "bold",
+    size: 8.5,
+  });
+
+  drawLine(ops, MARGIN_X, 736, PAGE_WIDTH - MARGIN_X, 736, {
+    color: COLORS.border,
+    width: 1,
+  });
+}
+
+function drawSummaryCards(
+  ops: PdfOp[],
+  exportedAt: string,
+  totalAssociates: number,
+  totalDependents: number,
+) {
+  const totalPeople = totalAssociates + totalDependents;
+  const gap = 12;
+  const cardWidth = (CONTENT_WIDTH - gap * 3) / 4;
+  const y = SUMMARY_TOP;
+  const cards = [
+    { label: "Total de associados", value: String(totalAssociates) },
+    { label: "Total de dependentes", value: String(totalDependents) },
+    { label: "Total geral", value: String(totalPeople) },
+    { label: "Data da emissão", value: exportedAt.split(",")[0] ?? exportedAt },
+  ];
+
+  cards.forEach((card, index) => {
+    const x = MARGIN_X + index * (cardWidth + gap);
+    drawRoundedRect(ops, x, y, cardWidth, 56, 12, {
+      fill: COLORS.cardBg,
+      stroke: COLORS.border,
+      strokeWidth: 1,
+    });
+    drawText(ops, card.label, x + 14, y + 38, {
+      color: COLORS.muted,
+      font: "bold",
+      size: 8.5,
+    });
+    drawText(ops, card.value, x + 14, y + 18, {
+      color: COLORS.ink,
+      font: "bold",
+      size: 17,
+    });
+  });
+}
+
+function drawPageFooter(
+  ops: PdfOp[],
+  exportedAt: string,
+  pageNumber: number,
+  totalPages: number,
+) {
+  drawLine(ops, MARGIN_X, FOOTER_TOP + 20, PAGE_WIDTH - MARGIN_X, FOOTER_TOP + 20, {
+    color: COLORS.border,
+    width: 1,
+  });
+  drawText(ops, "Associação Alemã de Juiz de Fora", MARGIN_X, FOOTER_TOP, {
+    color: COLORS.muted,
+    font: "bold",
+    size: 8.5,
+  });
+  drawText(ops, "Documento interno - contém dados pessoais.", 210, FOOTER_TOP, {
+    color: COLORS.warning,
+    size: 8.5,
+  });
+  drawText(
+    ops,
+    `Página ${pageNumber} de ${totalPages} · ${exportedAt}`,
+    PAGE_WIDTH - 180,
+    FOOTER_TOP,
+    {
+      color: COLORS.muted,
+      size: 8.5,
+    },
+  );
+}
+
+function drawAssociateCard(
+  ops: PdfOp[],
+  card: AssociateCardChunk,
+  top: number,
+  height: number,
+) {
+  const left = MARGIN_X;
+  const width = CONTENT_WIDTH;
+  const bottom = top - height;
+  const innerLeft = left + CARD_INNER_PADDING;
+  const innerRight = left + width - CARD_INNER_PADDING;
+  let currentY = top - CARD_INNER_PADDING;
+
+  drawRoundedRect(ops, left, bottom, width, height, 14, {
+    fill: COLORS.cardBg,
+    stroke: COLORS.border,
+    strokeWidth: 1,
+  });
+
+  if (card.isContinuation) {
+    drawText(
+      ops,
+      `Dependentes de ${card.associate.name} (continuação)`,
+      innerLeft,
+      currentY,
+      {
+        color: COLORS.ink,
+        font: "bold",
+        size: 13,
+      },
+    );
+    currentY -= 26;
+  } else {
+    drawText(ops, card.associate.name, innerLeft, currentY, {
+      color: COLORS.ink,
+      font: "bold",
+      size: 16,
+    });
+    drawBadge(
+      ops,
+      innerRight - 150,
+      currentY - 12,
+      70,
+      20,
+      humanizeStatus(card.associate.status),
+      getStatusBadge(card.associate.status),
+    );
+    drawBadge(
+      ops,
+      innerRight - 72,
+      currentY - 12,
+      72,
+      20,
+      card.associate.category || "Sem categoria",
+      {
+        fill: COLORS.tableHeader,
+        text: COLORS.ink,
+      },
+    );
+
+    currentY -= 22;
+    drawText(
+      ops,
+      `Matrícula ${card.associate.membershipNumber}`,
+      innerLeft,
+      currentY,
+      {
+        color: COLORS.muted,
+        font: "bold",
+        size: 10,
+      },
+    );
+    currentY -= 18;
+
+    const columnGap = 24;
+    const columnWidth = (width - CARD_INNER_PADDING * 2 - columnGap) / 2;
+
+    const leftColumn = [
+      ["Email", card.associate.email || "Não informado"],
+      ["CPF", card.associate.cpf || "Não informado"],
+      ["Nascimento", formatDate(card.associate.birthDate)],
+    ] as const;
+    const rightColumn = [
+      ["Telefone", card.associate.phone || "Não informado"],
+      ["RG", card.associate.rg || "Não informado"],
+      ["Nacionalidade", card.associate.nationality || "Não informada"],
+    ] as const;
+
+    let leftY = currentY;
+    let rightY = currentY;
+
+    for (const [label, value] of leftColumn) {
+      leftY = drawInfoBlock(ops, innerLeft, leftY, columnWidth, label, value);
+    }
+
+    for (const [label, value] of rightColumn) {
+      rightY = drawInfoBlock(
+        ops,
+        innerLeft + columnWidth + columnGap,
+        rightY,
+        columnWidth,
+        label,
+        value,
+      );
+    }
+
+    currentY = Math.min(leftY, rightY) - 8;
+    currentY = drawInfoBlock(
+      ops,
+      innerLeft,
+      currentY,
+      width - CARD_INNER_PADDING * 2,
+      "Endereço",
+      joinAddress(card.associate),
+    );
+
+    if (card.associate.observation) {
+      currentY = drawInfoBlock(
+        ops,
+        innerLeft,
+        currentY - 6,
+        width - CARD_INNER_PADDING * 2,
+        "Observação",
+        card.associate.observation,
+      );
+    }
+
+    currentY -= 2;
+  }
+
+  drawText(ops, "Dependentes", innerLeft, currentY, {
+    color: COLORS.ink,
+    font: "bold",
+    size: 11.5,
+  });
+  currentY -= 18;
+
+  if (!card.dependents.length && !card.hasMoreDependents) {
+    drawText(ops, "Nenhum dependente cadastrado.", innerLeft, currentY, {
+      color: COLORS.muted,
+      size: 10,
+    });
+    return;
+  }
+
+  const tableX = innerLeft;
+  const tableWidth = width - CARD_INNER_PADDING * 2;
+  const columns = [
+    { key: "membership", label: "Matrícula", width: 52 },
+    { key: "name", label: "Nome", width: 112 },
+    { key: "category", label: "Categoria", width: 60 },
+    { key: "cpf", label: "CPF", width: 68 },
+    { key: "rg", label: "RG", width: 48 },
+    { key: "birth", label: "Nascimento", width: 60 },
+    { key: "nationality", label: "Nacionalidade", width: tableWidth - 400 },
+  ] as const;
+
+  drawRoundedRect(ops, tableX, currentY - TABLE_HEADER_HEIGHT, tableWidth, TABLE_HEADER_HEIGHT, 8, {
+    fill: COLORS.tableHeader,
+    stroke: COLORS.border,
+    strokeWidth: 1,
+  });
+
+  let cursorX = tableX + 8;
+  for (const column of columns) {
+    drawText(ops, column.label, cursorX, currentY - 13, {
+      color: COLORS.muted,
+      font: "bold",
+      size: 8.5,
+    });
+    cursorX += column.width;
+  }
+
+  let rowTop = currentY - TABLE_HEADER_HEIGHT;
+  for (const dependent of card.dependents) {
+    drawLine(ops, tableX, rowTop - TABLE_ROW_HEIGHT, tableX + tableWidth, rowTop - TABLE_ROW_HEIGHT, {
+      color: COLORS.border,
+      width: 1,
+    });
+
+    const cells = [
+      dependent.membershipNumber || "Pendente",
+      truncateText(dependent.name, 26),
+      truncateText(dependent.category || "Não definida", 14),
+      dependent.cpf || "Não informado",
+      dependent.rg || "Não informado",
+      formatDate(dependent.birthDate),
+      truncateText(dependent.nationality || "Não informada", 14),
+    ];
+
+    let cellX = tableX + 8;
+    for (const [index, value] of cells.entries()) {
+      drawText(ops, value, cellX, rowTop - 14, {
+        color: COLORS.ink,
+        size: 8.7,
+      });
+      cellX += columns[index]?.width ?? 0;
+    }
+
+    rowTop -= TABLE_ROW_HEIGHT;
+  }
+
+  if (card.hasMoreDependents) {
+    drawText(
+      ops,
+      `Continua na próxima página (${card.endDependentIndexExclusive + 1}+).`,
+      innerRight - 170,
+      rowTop - 16,
+      {
+        color: COLORS.muted,
+        size: 8.5,
+      },
+    );
+  }
+}
+
+function paginateGroups(groups: AssociateGroup[]) {
+  const pages: PageModel[] = [{ cards: [], isFirstPage: true }];
+  let currentPage = pages[0];
+  let remainingHeight = currentPage.isFirstPage
+    ? FIRST_PAGE_CONTENT_TOP - BOTTOM_LIMIT
+    : OTHER_PAGE_CONTENT_TOP - BOTTOM_LIMIT;
+
+  for (const group of groups) {
+    let dependentIndex = 0;
+    let isContinuation = false;
+
+    while (true) {
+      const chunk = fitChunk(group, dependentIndex, isContinuation, remainingHeight);
+
+      if (!chunk) {
+        currentPage = { cards: [], isFirstPage: false };
+        pages.push(currentPage);
+        remainingHeight = OTHER_PAGE_CONTENT_TOP - BOTTOM_LIMIT;
+        continue;
+      }
+
+      currentPage.cards.push(chunk);
+      remainingHeight -= measureCardHeight(chunk) + CARD_GAP;
+
+      if (chunk.endDependentIndexExclusive >= group.dependents.length) {
+        break;
+      }
+
+      dependentIndex = chunk.endDependentIndexExclusive;
+      isContinuation = true;
+    }
+  }
+
+  return pages;
+}
+
+function fitChunk(
+  group: AssociateGroup,
+  dependentIndex: number,
+  isContinuation: boolean,
+  remainingHeight: number,
+): AssociateCardChunk | null {
+  const dependents = group.dependents;
+
+  if (!dependents.length) {
+    const candidate: AssociateCardChunk = {
+      associate: group.associate,
+      dependents: [],
+      endDependentIndexExclusive: 0,
+      hasMoreDependents: false,
+      isContinuation,
+      startDependentIndex: 0,
+    };
+
+    return measureCardHeight(candidate) <= remainingHeight ? candidate : null;
+  }
+
+  let endIndex = dependents.length;
+
+  while (endIndex > dependentIndex) {
+    const candidate: AssociateCardChunk = {
+      associate: group.associate,
+      dependents: dependents.slice(dependentIndex, endIndex),
+      endDependentIndexExclusive: endIndex,
+      hasMoreDependents: endIndex < dependents.length,
+      isContinuation,
+      startDependentIndex: dependentIndex,
+    };
+
+    if (measureCardHeight(candidate) <= remainingHeight) {
+      return candidate;
+    }
+
+    endIndex -= 1;
+  }
+
+  return null;
+}
+
+function measureCardHeight(card: AssociateCardChunk) {
+  let height = CARD_INNER_PADDING * 2;
+
+  if (card.isContinuation) {
+    height += 32;
+  } else {
+    height += 24; // nome
+    height += 18; // matrícula
+    height += 12; // espaço
+    height += measureInfoBlockHeight("Email", card.associate.email || "Não informado", 214);
+    height += 8;
+    height += measureInfoBlockHeight("Telefone", card.associate.phone || "Não informado", 214);
+    height += 8;
+    height += measureInfoBlockHeight("CPF", card.associate.cpf || "Não informado", 214);
+    height += 8;
+    height += measureInfoBlockHeight("RG", card.associate.rg || "Não informado", 214);
+    height += 8;
+    height += measureInfoBlockHeight(
+      "Nascimento",
+      formatDate(card.associate.birthDate),
+      214,
+    );
+    height += 8;
+    height += measureInfoBlockHeight(
+      "Nacionalidade",
+      card.associate.nationality || "Não informada",
+      214,
+    );
+    height += 10;
+    height += measureInfoBlockHeight("Endereço", joinAddress(card.associate), 460);
+    if (card.associate.observation) {
+      height += 8;
+      height += measureInfoBlockHeight("Observação", card.associate.observation, 460);
+    }
+    height += 8;
+  }
+
+  height += 18; // título dependentes
+  if (!card.dependents.length && !card.hasMoreDependents) {
+    height += 20;
+    return height;
+  }
+
+  height += TABLE_HEADER_HEIGHT;
+  height += card.dependents.length * TABLE_ROW_HEIGHT;
+  if (card.hasMoreDependents) {
+    height += 18;
+  }
+
+  return height;
+}
+
+function drawInfoBlock(
+  ops: PdfOp[],
+  x: number,
+  top: number,
+  width: number,
+  label: string,
+  value: string,
+) {
+  drawText(ops, label, x, top, {
+    color: COLORS.muted,
+    font: "bold",
+    size: 8.3,
+  });
+
+  const lines = wrapText(value, width, 10.4);
+  let currentY = top - 14;
+
+  for (const line of lines) {
+    drawText(ops, line, x, currentY, {
+      color: COLORS.ink,
+      size: 10.4,
+    });
+    currentY -= 13;
+  }
+
+  return currentY;
+}
+
+function measureInfoBlockHeight(label: string, value: string, width: number) {
+  const labelHeight = 12;
+  const lines = wrapText(value, width, 10.4);
+  return labelHeight + lines.length * 13;
+}
+
+function drawBadge(
+  ops: PdfOp[],
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  text: string,
+  colors: { fill: readonly [number, number, number]; text: readonly [number, number, number] },
+) {
+  drawRoundedRect(ops, x, y, width, height, 10, {
+    fill: colors.fill,
+    stroke: colors.fill,
+    strokeWidth: 1,
+  });
+  drawText(ops, truncateText(text, 18), x + 10, y + 6.5, {
+    color: colors.text,
+    font: "bold",
+    size: 8.4,
+  });
+}
+
+function drawRoundedRect(
+  ops: PdfOp[],
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+  options: {
+    fill?: readonly [number, number, number];
+    stroke?: readonly [number, number, number];
+    strokeWidth?: number;
+  },
+) {
+  const k = 0.5522847498;
+  const right = x + width;
+  const top = y + height;
+  const c = radius * k;
+
+  if (options.fill) {
+    ops.push(`${options.fill[0]} ${options.fill[1]} ${options.fill[2]} rg`);
+  }
+  if (options.stroke) {
+    ops.push(`${options.stroke[0]} ${options.stroke[1]} ${options.stroke[2]} RG`);
+  }
+  if (options.strokeWidth) {
+    ops.push(`${options.strokeWidth} w`);
+  }
+
+  ops.push(
+    `${x + radius} ${y} m`,
+    `${right - radius} ${y} l`,
+    `${right - radius + c} ${y} ${right} ${y + radius - c} ${right} ${y + radius} c`,
+    `${right} ${top - radius} l`,
+    `${right} ${top - radius + c} ${right - radius + c} ${top} ${right - radius} ${top} c`,
+    `${x + radius} ${top} l`,
+    `${x + radius - c} ${top} ${x} ${top - radius + c} ${x} ${top - radius} c`,
+    `${x} ${y + radius} l`,
+    `${x} ${y + radius - c} ${x + radius - c} ${y} ${x + radius} ${y} c`,
+    options.fill && options.stroke ? "B" : options.fill ? "f" : "S",
+  );
+}
+
+function drawCircle(
+  ops: PdfOp[],
+  centerX: number,
+  centerY: number,
+  radius: number,
+  options: {
+    fill?: readonly [number, number, number];
+    stroke?: readonly [number, number, number];
+  },
+) {
+  drawRoundedRect(ops, centerX - radius, centerY - radius, radius * 2, radius * 2, radius, {
+    fill: options.fill,
+    stroke: options.stroke,
+    strokeWidth: 1,
+  });
+}
+
+function drawLine(
+  ops: PdfOp[],
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  options: { color: readonly [number, number, number]; width: number },
+) {
+  ops.push(
+    `${options.color[0]} ${options.color[1]} ${options.color[2]} RG`,
+    `${options.width} w`,
+    `${x1} ${y1} m`,
+    `${x2} ${y2} l`,
+    "S",
+  );
+}
+
+function drawText(
+  ops: PdfOp[],
+  text: string,
+  x: number,
+  y: number,
+  options: {
+    color: readonly [number, number, number];
+    font?: FontKey;
+    size: number;
+  },
+) {
+  const fontName = options.font === "bold" ? "F2" : "F1";
+  ops.push(
+    "BT",
+    `${options.color[0]} ${options.color[1]} ${options.color[2]} rg`,
+    `/${fontName} ${options.size} Tf`,
+    `${x} ${y} Td`,
+    `(${escapePdfText(text)}) Tj`,
+    "ET",
+  );
+}
+
+function drawTextRight(
+  ops: PdfOp[],
+  text: string,
+  rightX: number,
+  y: number,
+  options: {
+    color: readonly [number, number, number];
+    font?: FontKey;
+    size: number;
+  },
+) {
+  const width = estimateTextWidth(text, options.size, options.font === "bold");
+  drawText(ops, text, rightX - width, y, options);
+}
+
+function groupRows(rows: AdminAssociateExportRow[]) {
+  const groups: AssociateGroup[] = [];
+  let currentGroup: AssociateGroup | null = null;
+
+  for (const row of rows) {
+    if (row.type === "associado") {
+      currentGroup = { associate: row, dependents: [] };
+      groups.push(currentGroup);
+      continue;
+    }
+
+    if (currentGroup) {
+      currentGroup.dependents.push(row);
+    }
+  }
+
+  return groups;
+}
+
+function joinAddress(row: AdminAssociateExportRow) {
+  const parts = [
+    row.addressStreet,
+    row.addressNumber,
+    row.addressComplement,
+    row.addressNeighborhood,
+    row.addressCity,
+    row.addressState,
+    row.zipCode,
+  ].filter(Boolean);
+
+  return parts.length ? parts.join(", ") : "Não informado";
+}
+
+function humanizeStatus(status: AdminAssociateExportRow["status"]) {
+  if (status === "active") return "Ativo";
+  if (status === "inactive") return "Inativo";
+  return "Suspenso";
+}
+
+function getStatusBadge(status: AdminAssociateExportRow["status"]) {
+  if (status === "active") {
+    return {
+      fill: COLORS.greenBadge,
+      text: COLORS.greenText,
+    };
+  }
+
+  return {
+    fill: COLORS.dangerBadge,
+    text: COLORS.dangerText,
+  };
+}
+
+function wrapText(text: string, width: number, fontSize: number) {
+  const maxChars = Math.max(18, Math.floor(width / (fontSize * 0.53)));
+
+  if (!text.trim() || text.length <= maxChars) {
+    return [text];
+  }
+
+  const words = text.split(" ");
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length <= maxChars) {
+      current = candidate;
+      continue;
+    }
+
+    if (current) {
+      lines.push(current);
+    }
+    current = word;
+  }
+
+  if (current) {
+    lines.push(current);
+  }
+
+  return lines;
+}
+
+function truncateText(text: string, maxChars: number) {
+  if (text.length <= maxChars) {
+    return text;
+  }
+
+  return `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+function estimateTextWidth(text: string, fontSize: number, bold = false) {
+  const factor = bold ? 0.57 : 0.52;
+  return text.length * fontSize * factor;
+}
+
+function formatDate(value: string) {
+  if (!value) {
+    return "Não informada";
+  }
+
+  const [year, month, day] = value.split("-");
+
+  if (!year || !month || !day) {
+    return value;
+  }
+
+  return `${day}/${month}/${year}`;
+}
+
+function escapePdfText(value: string) {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("(", "\\(")
+    .replaceAll(")", "\\)");
+}
+
+function encodeLatin1(value: string) {
+  const bytes = new Uint8Array(value.length);
+
+  for (let index = 0; index < value.length; index += 1) {
+    bytes[index] = value.charCodeAt(index) & 0xff;
+  }
+
+  return bytes;
+}
+
+function latin1ByteLength(value: string) {
+  return encodeLatin1(value).length;
+}

--- a/src/lib/supabase/admin-associates.ts
+++ b/src/lib/supabase/admin-associates.ts
@@ -25,6 +25,33 @@ export type AdminAssociateMembershipRecord = {
   status: "active" | "inactive" | "suspended";
 };
 
+export type AdminAssociateExportRow = {
+  addressCity: string;
+  addressComplement: string;
+  addressNeighborhood: string;
+  addressNumber: string;
+  addressState: string;
+  addressStreet: string;
+  associateResponsibleMembershipNumber: string;
+  associateResponsibleName: string;
+  birthDate: string;
+  category: string;
+  cpf: string;
+  email: string;
+  grantedAt: string;
+  hasPhoto: "Sim" | "Nao";
+  membershipNumber: string;
+  name: string;
+  nationality: string;
+  observation: string;
+  phone: string;
+  rg: string;
+  status: "active" | "inactive" | "suspended";
+  termAccepted: "Sim" | "Nao" | "";
+  type: "associado" | "dependente";
+  zipCode: string;
+};
+
 export type AssociateBootstrapGrantRecord = {
   claimedAt: string | null;
   email: string;
@@ -164,4 +191,90 @@ export async function getAdminAssociatesData(): Promise<AdminAssociatesData> {
     bootstrapGrants: [],
     memberships,
   };
+}
+
+export async function getAdminAssociateExportRows(): Promise<
+  | { access: Extract<AdminAccess, { status: "authorized" }>; rows: AdminAssociateExportRow[] }
+  | { access: Extract<AdminAccess, { status: "unconfigured" | "unauthenticated" | "denied" }> }
+> {
+  const result = await getAdminAssociatesData();
+
+  if (!isAuthorizedAdminAssociatesData(result)) {
+    return { access: result.access };
+  }
+
+  const rows = result.memberships.flatMap((membership) => {
+    const snapshot = membership.profileSnapshot;
+    const associateMembershipNumber = snapshot?.membershipNumber || "Pendente";
+    const associateName =
+      snapshot?.fullName || membership.profile.fullName || "Sem nome informado";
+
+    const associateRow: AdminAssociateExportRow = {
+      addressCity: snapshot?.addressCity || "",
+      addressComplement: snapshot?.addressComplement || "",
+      addressNeighborhood: snapshot?.addressNeighborhood || "",
+      addressNumber: snapshot?.addressNumber || "",
+      addressState: snapshot?.addressState || "",
+      addressStreet: snapshot?.addressStreet || "",
+      associateResponsibleMembershipNumber: associateMembershipNumber,
+      associateResponsibleName: associateName,
+      birthDate: snapshot?.birthDate || "",
+      category: snapshot?.category || "",
+      cpf: snapshot?.cpf || "",
+      email: membership.profile.email,
+      grantedAt: membership.grantedAt,
+      hasPhoto: snapshot?.photoUrl ? "Sim" : "Nao",
+      membershipNumber: associateMembershipNumber,
+      name: associateName,
+      nationality: snapshot?.nationality || "",
+      observation: snapshot?.observation || membership.notes || "",
+      phone: snapshot?.phone || "",
+      rg: snapshot?.rg || "",
+      status: membership.status,
+      termAccepted: snapshot?.termAccepted ? "Sim" : "Nao",
+      type: "associado",
+      zipCode: snapshot?.cep || "",
+    };
+
+    const dependentRows: AdminAssociateExportRow[] =
+      snapshot?.dependents.map((dependent) => ({
+        addressCity: "",
+        addressComplement: "",
+        addressNeighborhood: "",
+        addressNumber: "",
+        addressState: "",
+        addressStreet: "",
+        associateResponsibleMembershipNumber: associateMembershipNumber,
+        associateResponsibleName: associateName,
+        birthDate: dependent.birthDate || "",
+        category: dependent.category || "",
+        cpf: dependent.cpf || "",
+        email: "",
+        grantedAt: membership.grantedAt,
+        hasPhoto: "Nao",
+        membershipNumber: dependent.membershipNumber || "Pendente",
+        name: dependent.fullName,
+        nationality: dependent.nationality || "",
+        observation: "",
+        phone: "",
+        rg: dependent.rg || "",
+        status: membership.status,
+        termAccepted: "",
+        type: "dependente",
+        zipCode: "",
+      })) ?? [];
+
+    return [associateRow, ...dependentRows];
+  });
+
+  return {
+    access: result.access,
+    rows,
+  };
+}
+
+function isAuthorizedAdminAssociatesData(
+  data: AdminAssociatesData,
+): data is Extract<AdminAssociatesData, { access: { status: "authorized" } }> {
+  return data.access.status === "authorized";
 }


### PR DESCRIPTION
## Resumo

- implementa exportação de associados em Excel e PDF
- trata exportação como funcionalidade própria, desacoplada do grid da tela
- gera planilha Excel em aba única, com associado e dependentes em hierarquia de linhas
- gera PDF institucional com cabeçalho, resumo, cards de associados e seção de dependentes
- adiciona rotas dedicadas para download dos arquivos
- expõe ações de exportação em `/admin/associados`
- melhora a estrutura visual e a legibilidade do PDF
- adiciona cobertura de testes para geração e rotas de exportação

## Validação local

- [x] `npm run test`
- [x] `npm run build`
- [ ] `npm run lint`

## Validação funcional

- [x] exportação em Excel gera arquivo `.xls`
- [x] exportação em PDF gera arquivo `.pdf`
- [x] Excel usa uma única aba
- [x] associados aparecem primeiro e dependentes abaixo
- [x] PDF lista associados com seus respectivos dependentes
- [x] rotas de exportação respeitam autenticação e permissão administrativa
- [x] testes cobrem geradores e route handlers

## Observações

- a exportação lê diretamente os dados persistidos no banco
- o Excel preserva a hierarquia por colunas como `tipo_registro` e `matricula_associado_responsavel`
- o PDF usa layout institucional e inclui aviso de documento interno com dados pessoais
- a issue foi estruturada para manter exportação independente da listagem visual do admin

## Issue

- `#29`
